### PR TITLE
Added a sandstone.json configuration file, & more commands comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstone",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "license": "MIT",

--- a/src/_internals/commands/implementations/Advancement.ts
+++ b/src/_internals/commands/implementations/Advancement.ts
@@ -3,26 +3,79 @@ import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
 class AdvancementArguments extends Command {
+  /** Adds or removes all loaded advancements. */
   @command('everything', { isRoot: false, executable: true })
   everything = () => { }
 
+  /**
+   * Adds or removes a single advancement or criterion.
+   *
+   * @param advancement Specifies a valid namespaced id of the advancement to target.
+   *
+   * @param criterion Specifies a valid criterion of the advancement to manipulate.
+   * The command defaults to the entire advancement.
+   * If specified, the command refers to merely the criterion and not the entire advancement.
+   */
   @command('only', { isRoot: false, executable: true })
   only = (advancement: string, criterion?: string) => { }
 
+  /**
+   * Adds or removes an advancement and all its children advancements.
+   * Think of specifying everything from that advancement to the end.
+   *
+   * The exact order the operation is carried out in is:
+   *
+   *     specified advancement > child > child's child > ...
+   *
+   * When it operates on a child that branches, it iterates through all its children before continuing.
+   *
+   * @param advancement Specifies a valid namespaced id of the advancement to target.
+   */
   @command('from', { isRoot: false, executable: true })
   from = (advancement: string) => { }
 
+  /**
+   * Specifies an advancement, and adds or removes all its parent advancements, and all its children advancements.
+   * Think of specifying everything through the specified advancement, going both backwards and forwards.
+   *
+   * The exact order the operation is as if the command were executed with "until" specified, then with "from" specified:
+   *
+   *     parent > parent's parent > ... > root > specified advancement > child > child's child > ...
+   *
+   * @param advancement Specifies a valid namespaced id of the advancement to target.
+   */
   @command('through', { isRoot: false, executable: true })
   through = (advancement: string) => { }
 
+  /**
+   * Adds or removes an advancement and all its parent advancements until the root for addition/removal.
+   * Think of specifying everything from the start until that advancement.
+   *
+   * The exact order the operation is carried out in is:
+   *
+   *     parent > parent's parent > ... > root > specified advancement.
+   *
+   * @param advancement Specifies a valid namespaced id of the advancement to target.
+   */
   @command('until', { isRoot: false, executable: true })
   until = (advancement: string) => { }
 }
 
+/** Gives or takes an advancement from one or more players. */
 export class AdvancementCommand extends Command {
+  /**
+   * Adds specified advancements.
+   *
+   * @param targets Specifies one player or more.
+   */
   @command(['avancement', 'grant'], { isRoot: true, hasSubcommands: true, executable: false })
   grant = (targets: MultiplePlayersArgument) => new AdvancementArguments(this.commandsRoot)
 
+  /**
+   * Removes specified advancements.
+   *
+   * @param targets Specifies one player or more.
+   */
   @command(['avancement', 'revoke'], { isRoot: true, hasSubcommands: true, executable: false })
   revoke = (targets: MultiplePlayersArgument) => new AdvancementArguments(this.commandsRoot)
 }

--- a/src/_internals/commands/implementations/Attribute.ts
+++ b/src/_internals/commands/implementations/Attribute.ts
@@ -2,9 +2,6 @@ import type { SelectorArgument, SingleEntityArgument } from '@arguments'
 import { Command } from '../Command'
 import { command } from '../decorators'
 
-/**
- * @category attribute
- */
 export class AttributeOperation extends Command {
   /** Returns the total value of the specified attribute.
    * @category attribute
@@ -40,7 +37,7 @@ export class AttributeOperation extends Command {
 }
 
 /**
- * @category attribute
+ * Used to change or read attributes.
  */
 export class Attribute extends Command {
   @command('attribute', { isRoot: true, hasSubcommands: true, executable: false })

--- a/src/_internals/commands/implementations/Clone.ts
+++ b/src/_internals/commands/implementations/Clone.ts
@@ -5,17 +5,64 @@ import { Command } from '../Command'
 import { command } from '../decorators'
 
 export class CloneOptions extends Command {
+  /**
+   * Copy all blocks, overwriting all blocks of the destination region with the blocks from the source region.
+   *
+   * @param mode One of these three:
+   * - `force`: Force the clone even if the source and destination regions overlap.
+   * - `move`: Clone the source region to the destination region, then replace the source region with air. When used in filtered mask mode, only the cloned blocks are replaced with air.
+   * - `normal`: Don't move or force.
+   */
   @command('replace')
-  replace = (mode: 'force' | 'move' | 'normal') => { }
+  replace = (mode?: 'force' | 'move' | 'normal') => { }
 
+  /**
+   * Copy only non-air blocks. Blocks in the destination region that would otherwise be overwritten by air are left unmodified.
+   *
+   * @param mode One of these three:
+   * - `force`: Force the clone even if the source and destination regions overlap.
+   * - `move`: Clone the source region to the destination region, then replace the source region with air. When used in filtered mask mode, only the cloned blocks are replaced with air.
+   * - `normal`: Don't move or force.
+   */
   @command('masked')
-  masked = (mode: 'force' | 'move' | 'normal') => { }
+  masked = (mode?: 'force' | 'move' | 'normal') => { }
 
+  /**
+   * Clones only blocks with the block id specified by `filter`.
+   *
+   * @param filter The block ID to clone.
+   *
+   * @param mode One of these three:
+   * - `force`: Force the clone even if the source and destination regions overlap.
+   * - `move`: Clone the source region to the destination region, then replace the source region with air. When used in filtered mask mode, only the cloned blocks are replaced with air.
+   * - `normal`: Don't move or force.
+   */
   @command('filtered')
-  filtered = (filter: LiteralUnion<BLOCKS>, mode: 'force' | 'move' | 'normal') => { }
+  filtered = (filter: LiteralUnion<BLOCKS>, mode?: 'force' | 'move' | 'normal') => { }
 }
 
 export class Clone extends Command {
+  /**
+   * Clones blocks from one region to another.
+   *
+   * @param begin Specifies the coordinates of the first corner blocks of the source region.
+   *
+   * @param end Specifies the coordinates of the opposing corner blocks of the source region.
+   *
+   * @param destination Specifies the lower northwest corner of the destination region.
+   * It corresponds to the block with the lowest X-axis, Y-axis and Z-axis value.
+   *
+   * @example
+   *
+   * // Clone blocks from `0 0 0` to `8 8 8` at the current location.
+   * clone(abs(0, 0, 0), abs(8, 8, 8), rel(0, 0, 0))
+   *
+   * // Same as above, but only clone dirt blocks.
+   * clone(abs(0, 0, 0), abs(8, 8, 8), rel(0, 0, 0)).filtered('minecraft:dirt')
+   *
+   * // Move the current block 1 block above
+   * clone(rel(0, 0, 0), rel(0, 0, 0), rel(0, 1, 0)).replace('move')
+   */
   @command('clone', {
     isRoot: true,
     hasSubcommands: true,

--- a/src/_internals/commands/implementations/Data.ts
+++ b/src/_internals/commands/implementations/Data.ts
@@ -12,63 +12,132 @@ const modifyCmd = (name: string) => ['data', 'modify', name]
 const removeCmd = (name: string) => ['data', 'remove', name]
 
 class DataGet extends Command {
+  /**
+   * Get the NBT of a block at the given position.
+   *
+   * @param targetPos The coordinates of the block to get the NBT from.
+   * @param path The path of the NBT to get.
+   * @param scale The scale to multiply the NBT value by.
+   */
   @command(getCmd('block'), { isRoot: true, parsers: { '0': coordinatesParser } })
   block = (targetPos: Coordinates, path?: string, scale?: number) => { }
 
+  /**
+   * Get the NBT of a given entity.
+   *
+   * @param target The entity to get the NBT from.
+   * @param path The path of the NBT to get.
+   * @param scale The scale to multiply the NBT value by.
+   */
   @command(getCmd('entity'), { isRoot: true })
   entity = (target: SingleEntityArgument, path?: string, scale?: number) => { }
 
+  /**
+   * Get the NBT from a given storage path.
+   *
+   * @param target The storage to get the NBT from.
+   * @param path The path of the NBT to get.
+   * @param scale The scale to multiply the NBT value by.
+   */
   @command(getCmd('storage'), { isRoot: true })
   storage = (target: string, path?: string, scale?: number) => { }
 }
 
 class DataMerge extends Command {
+  /**
+   * Merge the NBT of a block at the given position, with the given NBT.
+   *
+   * @param targetPos The coordinates of the block to merge the NBT with.
+   * @param nbt The NBT to merge with.
+   */
   @command(mergeCmd('block'), { isRoot: true, parsers: { '0': coordinatesParser } })
   block = (targetPos: Coordinates, nbt: string) => { }
 
+  /**
+   * Merge the NBT of the given entity, with the given NBT.
+   *
+   * @param target The entity to merge the NBT with.
+   * @param nbt The NBT to merge with.
+   */
   @command(mergeCmd('entity'), { isRoot: true })
   entity = (target: SingleEntityArgument, nbt: string) => { }
 
+  /**
+   * Merge the NBT of the given storage path, with the given NBT.
+   *
+   * @param target The storage to merge the NBT with.
+   * @param nbt The NBT to merge with.
+   */
   @command(mergeCmd('storage'), { isRoot: true })
   storage = (target: string, nbt: string) => { }
 }
 
 class DataModifyValues extends Command {
+  /**
+   * Modify with the NBT of a block at the given position.
+   *
+   * @param sourcePosition The coordinates of the block to modify the NBT with.
+   * @param sourcePath The path of the NBT to modify with.
+   */
   @command(['from', 'block'], { parsers: { '0': coordinatesParser } })
   fromBlock = (sourcePosition: Coordinates, sourcePath: string) => { }
 
+  /**
+   * Modify with the NBT of a given entity.
+   *
+   * @param source The entity to modify the NBT with.
+   * @param sourcePath The path of the NBT to modify with.
+   */
   @command(['from', 'entity'])
   fromEntity = (source: SingleEntityArgument, sourcePath: string) => { }
 
+  /**
+   * Modify with the NBT of a given storage path.
+   *
+   * @param source The storage path to modify the NBT with.
+   * @param sourcePath The path of the NBT to modify with.
+   */
   @command(['from', 'storage'])
   fromStorage = (source: string, sourcePath: string) => { }
 
+  /**
+   * Modify the NBT witht the given value.
+   */
   @command('value')
   value = (value: string) => { }
 }
 
 class DataModifyType extends Command {
+  /** Append the source data onto the end of the pointed-to list. */
   get append() {
     this.commandsRoot.arguments.push('append')
     this.commandsRoot.executable = false
     return new DataModifyValues(this.commandsRoot)
   }
 
+  /**
+   * Insert the source data into the pointed-to list as element `index`, then shift higher elements one position upwards.
+   *
+   * @param index The index to insert the NBT to.
+   */
   @command('insert', { isRoot: false, hasSubcommands: true, executable: false })
-  insert = () => new DataModifyValues(this.commandsRoot)
+  insert = (index: number) => new DataModifyValues(this.commandsRoot)
 
+  /** Merge the source data into the pointed-to object. */
   get merge() {
     this.commandsRoot.arguments.push('merge')
     this.commandsRoot.executable = false
     return new DataModifyValues(this.commandsRoot)
   }
 
-  get preprend() {
+  /** Prepend the source data onto the beginning of the pointed-to list. */
+  get prepend() {
     this.commandsRoot.arguments.push('prepend')
     this.commandsRoot.executable = false
     return new DataModifyValues(this.commandsRoot)
   }
 
+  /** Set the tag specified by `targetPath` to the source data. */
   get set() {
     this.commandsRoot.arguments.push('set')
     this.commandsRoot.executable = false
@@ -77,37 +146,78 @@ class DataModifyType extends Command {
 }
 
 class DataModify extends Command {
+  /**
+   * Modify the NBT of a block at the given position.
+   *
+   * @param targetPos The coordinates of the block to modify the NBT from.
+   * @param path The path of the NBT to modify.
+   */
   @command(modifyCmd('block'), {
     isRoot: true, executable: false, hasSubcommands: true, parsers: { '0': coordinatesParser },
   })
   block = (targetPos: Coordinates, targetPath: string) => new DataModifyType(this.commandsRoot)
 
+  /**
+   * Modify the NBT of a given entity.
+   *
+   * @param target The entity to modify the NBT from.
+   * @param path The path of the NBT to modify.
+   */
   @command(modifyCmd('entity'), { isRoot: true, executable: false, hasSubcommands: true })
   entity = (target: SingleEntityArgument, targetPath: string) => new DataModifyType(this.commandsRoot)
 
+  /**
+   * Modify the NBT from a given storage path.
+   *
+   * @param target The storage to modify the NBT from.
+   * @param path The path of the NBT to modify.
+   */
   @command(modifyCmd('storage'), { isRoot: true, executable: false, hasSubcommands: true })
   storage = (target: string, targetPath: string) => new DataModifyType(this.commandsRoot)
 }
 
 class DataRemove extends Command {
+  /**
+   * Remove the NBT of a block at the given position.
+   *
+   * @param targetPos The coordinates of the block to remove the NBT from.
+   * @param path The path of the NBT to remove.
+   */
   @command(removeCmd('block'), {
     isRoot: true, executable: false, hasSubcommands: true, parsers: { '0': coordinatesParser },
   })
   block = (targetPos: Coordinates, targetPath: string) => { }
 
+  /**
+   * Remove the NBT of a given entity.
+   *
+   * @param target The entity to remove the NBT from.
+   * @param path The path of the NBT to remove.
+   */
   @command(removeCmd('entity'), { isRoot: true, executable: false, hasSubcommands: true })
   entity = (target: SingleEntityArgument, targetPath: string) => { }
 
+  /**
+   * Remove the NBT from a given storage path.
+   *
+   * @param target The storage to remove the NBT from.
+   * @param path The path of the NBT to remove.
+   */
   @command(removeCmd('storage'), { isRoot: true, executable: false, hasSubcommands: true })
   storage = (target: string, targetPath: string) => { }
 }
 
+/** Allows to get, merge, modify, and remove NBT data of a block entity, entity, or Command NBT storage. */
 export class Data extends Command {
+  /** Read off the entire NBT data or the subsection of the NBT data from the targeted block position or entity, scaled by `scale` if specified. */
   get = new DataGet(this.commandsRoot)
 
+  /** Merge the NBT data from the sourced block position or entity with the specified `nbt` data. */
   merge = new DataMerge(this.commandsRoot)
 
+  /** Modify the NBT data from the sourced block position or entity, with the specified operation and the given NBT. */
   modify = new DataModify(this.commandsRoot)
 
+  /** Removes NBT data at `path` from the targeted block position or entity. Player NBT data cannot be removed. */
   remove = new DataRemove(this.commandsRoot)
 }

--- a/src/_internals/commands/implementations/Datapack.ts
+++ b/src/_internals/commands/implementations/Datapack.ts
@@ -2,26 +2,70 @@ import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
 class DatapackEnable extends Command {
+  /**
+   * Load this pack before all others. It will have the lowest priority.
+   */
   @command('first')
   first = () => {}
 
+  /**
+   * Load this pack after all others. It will have the highest priority.
+   */
   @command('last')
   last = () => {}
 
+  /**
+   * Load this pack just before an existing pack.
+   * It will have a lower priority than the existing one.
+   *
+   * @param name The name of the existing datapack.
+   */
   @command('before')
   before = (name: string) => {}
 
+  /**
+   * Load this pack just after an existing pack.
+   * It will have a higher priority than the existing one.
+   *
+   * @param name The name of the existing datapack.
+   */
   @command('after')
   after = (name: string) => {}
 }
 
+/** Controls the loading/unloading of data packs. */
 export class DatapackCommand extends Command {
+  /**
+   * Disable the specified pack.
+   *
+   * @param name Specifies the name of the data pack.
+   */
   @command(['datapack', 'disable'], { isRoot: true })
   disable = (name: string) => {}
 
+  /**
+   * Enable the specified pack.
+   *
+   * @param name Specifies the name of the data pack.
+   *
+   * @example
+   *
+   * // Enable `myDatapack`, and give it the highest priority
+   * datapack.enable('myDatapack').last()
+   *
+   * // Enable `myDatapack`, just before `importantDatapack`.
+   * // `mydatapack` will have a lower priority.
+   * datapack.enable('myDatapack').before('importantDatapack')
+   */
   @command(['datapack', 'enable'], { isRoot: true, hasSubcommands: true })
   enable = (name: string) => new DatapackEnable(this.commandsRoot)
 
+  /** List all data packs, or list only the available/enabled ones.
+   *
+   * Hovering over the data packs in the chat output shows their description defined in their pack.mcmeta.
+   *
+   * @param typ `"available"` to only show available datapacks, `"enabled"` to only show enabled ones.
+   */
   @command(['datapack', 'list'], { isRoot: true })
   list = (type: 'available' | 'enabled') => {}
 }

--- a/src/_internals/commands/implementations/Debug.ts
+++ b/src/_internals/commands/implementations/Debug.ts
@@ -1,13 +1,22 @@
 import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
+/**
+ * Starts or stops a debugging session.
+ * While active, includes notifications about potential performance bottlenecks in the console.
+ * When stopped, creates a profiler results file in the folder `debug`.
+ */
 export class Debug extends Command {
+  /** Starts a new debug profiling session. */
   @command(['debug', 'start'], { isRoot: true })
   start = () => {}
 
+  /** Stops the active debug profiling session. */
   @command(['debug', 'stop'], { isRoot: true })
   stop = () => {}
 
+  /** Used to get more detailed information while debugging performance.
+   * Saves information in the `.minecraft\debug` folder in the form of a zip file. */
   @command(['debug', 'report'], { isRoot: true })
   report = () => {}
 }

--- a/src/_internals/commands/implementations/DefaultGamemode.ts
+++ b/src/_internals/commands/implementations/DefaultGamemode.ts
@@ -3,6 +3,15 @@ import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
 export class DefaultGamemode extends Command {
+  /**
+   * Sets the default game mode (creative, survival, etc.) for new players entering a multiplayer server.
+   *
+   * @param mode Specifies the default game mode for new players. Must be one of the following:
+   * - `survival` for survival mode
+   * - `creative` for creative mode
+   * - `adventure` for adventure mode
+   * - `spectator` for spectator mode
+   */
   @command('defaultgamemode', { isRoot: true })
   defaultgamemode = (mode: GAMEMODES) => {}
 }

--- a/src/_internals/commands/implementations/Difficulty.ts
+++ b/src/_internals/commands/implementations/Difficulty.ts
@@ -3,6 +3,15 @@ import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
 export class Difficulty extends Command {
+  /**
+   * Sets the new difficulty level. Must be one of the following:
+   * - `peaceful` for peaceful difficulty
+   * - `easy` for easy difficulty
+   * - `normal` for normal difficulty
+   * - `hard` for hard difficulty
+   *
+   * If unspecified, querys current difficulty rather than changes it.‌
+   */
   @command('difficulty', { isRoot: true })
-  difficulty = (difficulty: DIFFICULTIES) => {}
+  difficulty = (difficulty?: DIFFICULTIES) => {}
 }

--- a/src/_internals/config.ts
+++ b/src/_internals/config.ts
@@ -1,0 +1,16 @@
+import path from 'path'
+import fs from 'fs'
+
+export function getConfigFile(): Record<string, string> {
+// Directory of the file that's being ran
+  const fileDir = path.dirname(process.argv[1])
+
+  const configPath = path.join(fileDir, 'sandstone.json')
+
+  try {
+    const configFile = fs.readFileSync(configPath)
+    return JSON.parse(configFile.toString())
+  } catch (e) {
+    return {}
+  }
+}

--- a/src/_internals/datapack/Datapack.ts
+++ b/src/_internals/datapack/Datapack.ts
@@ -4,17 +4,15 @@ import type {
 } from '@arguments'
 import { CommandsRoot } from '@commands'
 import { Flow } from '@flow'
-import { McFunction, McFunctionOptions } from '@resources/McFunction'
-import { Objective, ObjectiveClass, SelectorCreator } from '@variables'
-import { AdvancementCommand } from '@commands/implementations'
 import { Advancement } from '@resources'
+import { McFunction, McFunctionOptions } from '@resources/McFunction'
 import { Predicate } from '@resources/Predicate'
-import { saveDatapack, SaveOptions } from './saveDatapack'
+import { Objective, ObjectiveClass, SelectorCreator } from '@variables'
 import { CommandArgs, toMcFunctionName } from './minecraft'
 import {
-  FolderOrFile,
-  FunctionResource, ResourceOnlyTypeMap, ResourcePath, ResourcesTree, ResourceTypeMap, ResourceTypes,
+  FunctionResource, ResourceOnlyTypeMap, ResourcePath, ResourcesTree, ResourceTypes,
 } from './resourcesTree'
+import { saveDatapack, SaveOptions } from './saveDatapack'
 
 export interface McFunctionReturn<T extends unknown[]> {
   (...args: T): void
@@ -55,15 +53,6 @@ export default class Datapack {
 
     this.commandsRoot = new CommandsRoot(this)
     this.flow = new Flow(this.commandsRoot)
-  }
-
-  /**
-   * Change the default namespace of the datapack.
-   *
-   * ⚠️ You must do this **before** creating any resource (functions, advancements, predicates...
-   */
-  setDefaultNamespace(namespace: string) {
-    this.defaultNamespace = namespace
   }
 
   getResourcePath(functionName: string): {

--- a/src/_internals/datapack/Datapack.ts
+++ b/src/_internals/datapack/Datapack.ts
@@ -57,6 +57,15 @@ export default class Datapack {
     this.flow = new Flow(this.commandsRoot)
   }
 
+  /**
+   * Change the default namespace of the datapack.
+   *
+   * ⚠️ You must do this **before** creating any resource (functions, advancements, predicates...
+   */
+  setDefaultNamespace(namespace: string) {
+    this.defaultNamespace = namespace
+  }
+
   getResourcePath(functionName: string): {
     namespace: string
     path: string[]

--- a/src/_internals/index.ts
+++ b/src/_internals/index.ts
@@ -1,7 +1,11 @@
 import { Datapack } from './datapack'
 import { Flow } from './flow'
 
-export const datapack = new Datapack('default')
+import { getConfigFile } from './config'
+
+const configFile = getConfigFile()
+
+export const datapack = new Datapack(configFile?.namespace ?? 'default')
 export const { commandsRoot } = datapack
 export const _: Omit<Flow, 'arguments'> = datapack.flow
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,11 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-require('module-alias/register')(__dirname)
+require('module-alias')(__dirname)
 
 // eslint-disable-next-line import/first
 import { datapack } from './_internals'
 
 export const {
-  mcfunction, save: saveDatapack, Advancement, Predicate, setDefaultNamespace,
+  mcfunction, save: saveDatapack, Advancement, Predicate,
 } = datapack
 
 export { _ } from './_internals'

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-require('module-alias')(__dirname)
+require('module-alias/register')(__dirname)
+
 // eslint-disable-next-line import/first
 import { datapack } from './_internals'
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,7 +5,7 @@ require('module-alias/register')(__dirname)
 import { datapack } from './_internals'
 
 export const {
-  mcfunction, save: saveDatapack, Advancement, Predicate,
+  mcfunction, save: saveDatapack, Advancement, Predicate, setDefaultNamespace,
 } = datapack
 
 export { _ } from './_internals'


### PR DESCRIPTION
CHANGELOG:
- More commands now have comments
- You can now create a "sandstone.json" file, that must be **in the same folder** than the file you're running. It can contain a "namespace" key, that gives the default namespace for Sandstone to use.

Example:
```json
{
  "namespace": "mynamespace"
}
```