### PR TITLE
Sandstone 0.4.4 - A few improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstone",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "license": "MIT",

--- a/src/_internals/arguments/resources/predicate.ts
+++ b/src/_internals/arguments/resources/predicate.ts
@@ -97,6 +97,6 @@ export type PredicateCondition = (
       /** If true, the condition evaluates to true only if it's thundering. */
       thundering?: boolean
   }>
-)
+) |never
 
 export type PredicateType = ObjectOrArray<PredicateCondition>

--- a/src/_internals/datapack/Datapack.ts
+++ b/src/_internals/datapack/Datapack.ts
@@ -3,20 +3,18 @@ import type {
   AdvancementType, JsonTextComponent, LootTableType, OBJECTIVE_CRITERION, PredicateType, RecipeType, TAG_TYPES,
 } from '@arguments'
 import { CommandsRoot } from '@commands'
-import { RecipeCommand } from '@commands/implementations'
 import { Flow } from '@flow'
-import type { HintedTagValues, McFunctionOptions } from '@resources'
+import type { HintedTagStringType, McFunctionOptions } from '@resources'
 import {
-  Recipe,
-  Advancement, LootTable, McFunction, Predicate, Tag,
+  Advancement, LootTable, McFunction, Predicate, Recipe,
+  Tag,
 } from '@resources'
-
 import type { ObjectiveClass } from '@variables'
 import { Objective, SelectorCreator } from '@variables'
 import type { CommandArgs } from './minecraft'
 import { toMcFunctionName } from './minecraft'
 import type {
-  FunctionResource, ResourceOnlyTypeMap, ResourcePath, ResourceTypes, TagObjectValue,
+  FunctionResource, ResourceOnlyTypeMap, ResourcePath, ResourceTypes, TagSingleValue,
 } from './resourcesTree'
 import { ResourcesTree } from './resourcesTree'
 import type { SaveOptions } from './saveDatapack'
@@ -27,7 +25,7 @@ export interface McFunctionReturn<T extends unknown[]> {
 
   schedule: (delay: number | LiteralUnion<'1t' | '1s' | '1d'>, type?: 'append' | 'replace', ...callbackArgs: T) => void
 
-  getNameFromArgs: (...args: T) => string
+  getName: (...args: T) => string
 
   clearSchedule: (...args: T) => void
 }
@@ -361,7 +359,7 @@ export default class Datapack {
 
   Predicate = (name: string, predicate: PredicateType) => new Predicate(this.commandsRoot, name, predicate)
 
-  Tag = <T extends TAG_TYPES>(type: T, name: string, values: HintedTagValues<T>, replace?: boolean) => new Tag(this, type, name, values as TagObjectValue<string>[], replace)
+  Tag = <T extends TAG_TYPES>(type: T, name: string, values: TagSingleValue<HintedTagStringType<T>>[], replace?: boolean) => new Tag(this, type, name, values, replace)
 
   LootTable = (name: string, lootTable: LootTableType) => new LootTable(this, name, lootTable)
 

--- a/src/_internals/datapack/resourcesTree.ts
+++ b/src/_internals/datapack/resourcesTree.ts
@@ -29,8 +29,8 @@ export type File<T extends Record<string, unknown>, P extends ResourcePath = Res
 type FunctionProperties = { commands: CommandArgs[] }
 export type FunctionResource = FolderOrFile<FunctionProperties>
 
-export type TagObjectValue<T extends unknown = string> = { id: T, required: boolean }
-type TagProperties = { values: (TagObjectValue | string)[], replace?: boolean }
+export type TagSingleValue<T> = T | { id: T, required: boolean }
+type TagProperties = { values: TagSingleValue<string>[], replace?: boolean }
 type TagPath = readonly [
   namespace: string,
   type: TAG_TYPES,

--- a/src/_internals/generalTypes.ts
+++ b/src/_internals/generalTypes.ts
@@ -2,12 +2,15 @@
  * Allows to get autocompletion on string unions, while still allowing generic strings.
  * @see https://github.com/microsoft/TypeScript/issues/29729#issuecomment-700527227
  */
-export type LiteralUnion<T extends string> = T | (Pick<string, never> & {
+export type LiteralUnion<T extends string> = T | (Omit<string, keyof string> & {
   /**
    * Ignore this property.
    * @deprecated
+   * @internal
+   * @hidden
+   * @ignore
    */
-  _?: never
+  trimStart: string['trimStart']
 });
 
 export type AtLeastOne<T> = [T, ...T[]]

--- a/src/_internals/resources/McFunction.ts
+++ b/src/_internals/resources/McFunction.ts
@@ -200,15 +200,15 @@ export class McFunction<T extends any[]> {
   }
 
   getNameFromArgs = (...args: T): string => {
-    const jsonRepresentation = JSON.stringify(args)
-    const mcfunction = this.alreadyInitializedParameters.get(jsonRepresentation)
+    const repr = hash(args)
+    const mcfunction = this.alreadyInitializedParameters.get(repr)
 
     if (mcfunction) {
       return mcfunction.name
     }
 
     this.callAndRegister(args)
-    return this.alreadyInitializedParameters.get(jsonRepresentation)?.name as string
+    return this.alreadyInitializedParameters.get(repr)?.name as string
   }
 
   generateInitialFunction = () => {

--- a/src/_internals/resources/Predicate.ts
+++ b/src/_internals/resources/Predicate.ts
@@ -29,4 +29,8 @@ export class Predicate extends ConditionClass {
       value: ['predicate', this.name],
     }
   }
+
+  toString() {
+    return this.name
+  }
 }

--- a/src/_internals/variables/Selector.ts
+++ b/src/_internals/variables/Selector.ts
@@ -146,15 +146,31 @@ export type SelectorProperties<MustBeSingle extends boolean, MustBePlayer extend
     MustBeSingle extends true ? { limit: 0 | 1 } : { limit?: number }
   )
 
+// Sanitize score values. null => '', Infinity => '', any number => itself
+function sanitizeValue(value: number | null): string {
+  if (value === undefined || value === null) {
+    return ''
+  }
+
+  if (Number.isFinite(value)) {
+    return value.toString()
+  }
+
+  // Value is Infinity or -Infinity
+  return ''
+}
+
+// Returns the string representation of a score range. [0, null] => '0..', [-Infinity, 5] => '..5', 8 => '8'
 function parseScore(scores: ScoreArgument): string {
   return `{${Object.entries(scores).map(([scoreName, value]) => {
     if (Array.isArray(value)) {
-      return [scoreName, `${value[0] ?? ''}..${value[1] ?? ''}`].join('=')
+      return [scoreName, `${sanitizeValue(value[0])}..${sanitizeValue(value[1])}`].join('=')
     }
     return [scoreName, value].join('=')
   }).join(', ')}}`
 }
 
+// Returns the string representation of advancements
 function parseAdvancements(advancements: AdvancementsArgument): string {
   return `{${Object.entries(advancements).map(([advancementName, value]) => {
     if (typeof value === 'boolean') {

--- a/src/_internals/variables/Selector.ts
+++ b/src/_internals/variables/Selector.ts
@@ -4,6 +4,7 @@ import type {
   ENTITY_TYPES, TextComponentObject,
 } from '@arguments'
 import type { CommandsRoot } from '@commands'
+import type { Predicate } from '@resources'
 import type { LiteralUnion } from '../generalTypes'
 import type { ConditionClass } from './abstractClasses'
 import { ComponentClass } from './abstractClasses'
@@ -116,7 +117,7 @@ export type SelectorProperties<MustBeSingle extends boolean, MustBePlayer extend
   advancements?: AdvancementsArgument
 
   /** Select all targets that match the specified predicate. */
-  predicate?: string | string[]
+  predicate?: string | string[] | Predicate | Predicate[]
 } & ({} | {
   /** Define a position on the X-axis in the world the selector starts at,
    * for use with the `distance` argument or the volume arguments, `dx`, `dy` and `dz`. */

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,8 +1,9 @@
+import type { LiteralUnion } from '../src/arguments'
 import {
   execute, gamerule, give, raw, say, tellraw,
 } from '../src/commands'
 import {
-  mcfunction, Predicate, Recipe, saveDatapack, _,
+  mcfunction, Predicate, Recipe, saveDatapack, Tag, _,
 } from '../src/core'
 import { createObjective, Selector } from '../src/variables'
 
@@ -19,15 +20,12 @@ const myPredicate = Predicate('mypred', {
 
 const myScore = createObjective('aa', 'dummy')
 
-const me = Selector('@s', {
-  predicate: myPredicate,
-  scores: {
-    [myScore.name]: [0, Infinity],
-  },
-})
+const cc = mcfunction('cc', () => {})
 
-mcfunction('cc', () => {
-  give(me, 'minecraft:blue_ice')
-})
+Tag('functions', 'hi2', [
+  'test:mc',
+  'minecraft:acacia_button',
+  cc,
+])
 
 saveDatapack('My datapack', { verbose: true, world: 'Crea1_15' })

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -17,8 +17,13 @@ const myPredicate = Predicate('mypred', {
   },
 })
 
+const myScore = createObjective('aa', 'dummy')
+
 const me = Selector('@s', {
   predicate: myPredicate,
+  scores: {
+    [myScore.name]: [0, Infinity],
+  },
 })
 
 mcfunction('cc', () => {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -2,19 +2,27 @@ import {
   execute, gamerule, give, raw, say, tellraw,
 } from '../src/commands'
 import {
-  mcfunction, Recipe, saveDatapack, _,
+  mcfunction, Predicate, Recipe, saveDatapack, _,
 } from '../src/core'
 import { createObjective, Selector } from '../src/variables'
 
-Recipe('test', {
-  type: 'blasting',
-  ingredient: { item: 'minecraft:acacia_boat' },
-  result: 'minecraft:coal',
-  experience: 0,
+const myPredicate = Predicate('mypred', {
+  condition: 'minecraft:entity_scores',
+  entity: 'killer',
+  scores: {
+    cc: {
+      max: 0,
+      min: 2,
+    },
+  },
+})
+
+const me = Selector('@s', {
+  predicate: myPredicate,
 })
 
 mcfunction('cc', () => {
-  give(Selector('@s', { scores: { xx: [0, 1] } }), 'minecraft:blue_ice')
+  give(me, 'minecraft:blue_ice')
 })
 
 saveDatapack('My datapack', { verbose: true, world: 'Crea1_15' })


### PR DESCRIPTION
Changelog:
- Selectors `predicate` field now directly accepts a predicate
- Selectors `scores` field now accepts +Infinity and -Infinity when specifying boundaries. Example: `scores: {deaths: [1, +Infinity]}`
- Fixed `getName` being not accessible on mcfunctions
- Function tags now directly accept mcfunctions

