### PR TITLE
v0.4.5: Path aliases now resolved at build time - Fixed while/for loops not working properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "url": "git+https://github.com/TheMrZZ/sandstone.git"
   },
   "scripts": {
-    "build:watch": "tsc --watch --incremental --pretty",
-    "build": "node scripts/clean.js && tsc && node scripts/setupPackage.js",
+    "build:watch": "ttsc --watch --incremental --pretty",
+    "build": "node scripts/clean.js && ttsc && node scripts/setupPackage.js",
     "test": "node dist/tests/test.js",
     "test:watch": "nodemon -q dist/tests/test.js",
     "publishToNpm": "npm run build && npm publish dist/src"
@@ -43,23 +43,15 @@
     "eslint-plugin-prettier": "^3.1.4",
     "nodemon": "^2.0.4",
     "prettier": "^2.0.5",
-    "typescript": "^4.1.0-dev.20200930"
+    "ttypescript": "^1.5.12",
+    "typescript": "^4.1.0-dev.20200930",
+    "typescript-transform-paths": "^2.0.1"
   },
   "dependencies": {
-    "module-alias": "^2.2.2",
     "object-hash": "^2.0.3"
   },
   "engines": {
     "node": ">=14.0.0"
-  },
-  "_moduleAliases": {
-    "@arguments": "dist/src/_internals/arguments",
-    "@commands": "dist/src/_internals/commands",
-    "@datapack": "dist/src/_internals/datapack",
-    "@resources": "dist/src/_internals/resources",
-    "@variables": "dist/src/_internals/variables",
-    "@flow": "dist/src/_internals/flow",
-    "@": "dist/src/_internals"
   },
   "bugs": {
     "url": "https://github.com/TheMrZZ/sandstone/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstone",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "license": "MIT",

--- a/scripts/setupPackage.js
+++ b/scripts/setupPackage.js
@@ -7,7 +7,7 @@ rootDir = __dirname + '/..'
 distDir = rootDir + '/dist/src'
 
 /*
-Copies the root package.json but removes the scripts and dev dependencies which are not needed in the package. 
+Copies the root package.json but removes the scripts and dev dependencies which are not needed in the package.
 It also fixes the main entry point to the package.
 */
 const source = fs.readFileSync(__dirname + "/../package.json").toString('utf-8');
@@ -21,15 +21,6 @@ if (sourceObj.types.startsWith("dist/src/")) {
     sourceObj.types = sourceObj.types.slice(9);
 }
 
-sourceObj._moduleAliases = Object.fromEntries(
-    Object.entries(sourceObj._moduleAliases).map(([key, value]) => {
-        if (value.startsWith('dist/src/')) {
-            value = value.slice(9)
-        }
-        return [key, value]
-    })
-)
-
 // Remove sandstone from dependencies
 delete sourceObj.dependencies.sandstone
 
@@ -37,3 +28,4 @@ fs.writeFileSync(distDir + "/package.json", Buffer.from(JSON.stringify(sourceObj
 fs.writeFileSync(distDir + "/version.txt", Buffer.from(sourceObj.version, "utf-8"));
 fs.copyFileSync(rootDir + '/README.md', distDir + '/README.md')
 fs.copyFileSync(rootDir + '/LICENSE', distDir + '/LICENSE')
+fs.copyFileSync(rootDir + '/tsconfig.json', distDir + '/.tsconfig.json')

--- a/src/_internals/flow/Flow.ts
+++ b/src/_internals/flow/Flow.ts
@@ -70,7 +70,8 @@ export class Flow {
     // At the end of the callback, add the given conditions to call it again
     if (config.loopCondition) {
       registerCondition(this.commandsRoot, config.condition, args)
-      this.commandsRoot.addAndRegister('function', callbackFunctionName)
+      this.commandsRoot.inExecute = true
+      this.commandsRoot.function(callbackFunctionName)
     }
 
     // Exit the callback

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -1,5 +1,2 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('module-alias')(__dirname)
-
 export * from './_internals/arguments'
 export * from './_internals/generalTypes'

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('module-alias')(__dirname)
-
-// eslint-disable-next-line import/first
 import { commandsRoot } from './_internals'
 
 export const {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('module-alias')(__dirname)
-
-// eslint-disable-next-line import/first
 import { datapack } from './_internals'
 
 export const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('module-alias')(__dirname)
-
 export * as commands from './commands'
 
 export * as variables from './variables'

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('module-alias')(__dirname)
-// eslint-disable-next-line import/first
 import { datapack } from './_internals'
 
 export {

--- a/tests/menu.ts
+++ b/tests/menu.ts
@@ -5,7 +5,8 @@ import {
   clear, execute, replaceitem,
 } from '../src/commands'
 import { mcfunction } from '../src/core'
-import { createObjective, PlayerScore, Variable } from '../src/variables'
+import type { PlayerScore } from '../src/variables'
+import { createObjective, Variable } from '../src/variables'
 import { nbtParser, SelectorCreator, _ } from '../src/_internals'
 
 /** A menu action can either be: a new menu bar to open, or a callback. */

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -13,9 +13,10 @@ import { Menu } from './menu'
 mcfunction('test', () => {
   const counter = Variable(0)
 
-  _.while(_.block(rel(0, 0, 0), 'minecraft:acacia_button'), () => {
+  _.while(counter.lowerOrEqualThan(10), () => {
     say('hi')
     say('ho')
+    counter.add(1)
   })
 })
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -5,27 +5,18 @@ import {
 import {
   mcfunction, Predicate, Recipe, saveDatapack, Tag, _,
 } from '../src/core'
-import { createObjective, Selector } from '../src/variables'
+import {
+  createObjective, rel, Selector, Variable,
+} from '../src/variables'
+import { Menu } from './menu'
 
-const myPredicate = Predicate('mypred', {
-  condition: 'minecraft:entity_scores',
-  entity: 'killer',
-  scores: {
-    cc: {
-      max: 0,
-      min: 2,
-    },
-  },
+mcfunction('test', () => {
+  const counter = Variable(0)
+
+  _.while(_.block(rel(0, 0, 0), 'minecraft:acacia_button'), () => {
+    say('hi')
+    say('ho')
+  })
 })
-
-const myScore = createObjective('aa', 'dummy')
-
-const cc = mcfunction('cc', () => {})
-
-Tag('functions', 'hi2', [
-  'test:mc',
-  'minecraft:acacia_button',
-  cc,
-])
 
 saveDatapack('My datapack', { verbose: true, world: 'Crea1_15' })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,15 @@
 {
   "compilerOptions": {
     /* Custom paths */
+    "plugins": [
+      {
+        "transform": "typescript-transform-paths"
+      },
+      {
+        "transform": "typescript-transform-paths",
+        "afterDeclarations": true
+      }
+    ],
     "baseUrl": ".",
     "paths": {
       "@arguments": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,11 +1358,6 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-module-alias@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
-  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1691,7 +1686,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.10.0, resolve@^1.13.1, resolve@^1.17.0:
+resolve@>=1.9.0, resolve@^1.10.0, resolve@^1.13.1, resolve@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -1962,6 +1957,13 @@ tsutils@^3.17.1:
   dependencies:
     tslib "^1.8.1"
 
+ttypescript@^1.5.12:
+  version "1.5.12"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.12.tgz#27a8356d7d4e719d0075a8feb4df14b52384f044"
+  integrity sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==
+  dependencies:
+    resolve ">=1.9.0"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -1980,6 +1982,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript-transform-paths@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-transform-paths/-/typescript-transform-paths-2.0.1.tgz#1b4e53df3e07f400bf113cd0be3a8c14e40eac37"
+  integrity sha512-B54vhxIP6g3ESXI+SyrKAYeiQ9cRJ/IKp0kDZy9xYcR8HyndY7AdKFK5C5bIygccCutYIBXvBnjbhnXeqauRcw==
 
 typescript@^4.1.0-dev.20200930:
   version "4.1.0-dev.20200930"


### PR DESCRIPTION
Changelog: 
- Path aliases were previously resolved at runtime, using `module-alias`. However, it didn't resolve in declaration (.d.ts) files, leading to incorrect type inferring. To solve this problem, Sandstone now uses a new Typescript compiler, `ttypescript`. It allows the use of compiler plugins: Sandstone uses the `typescript-transform-paths` plugin, which resolves all path aliases at build time.
- While/for loops weren't including the `run` keyword inside the recursive function. It is now solved.