### PR TITLE
Added delaying statements

### DIFF
--- a/src/_internals/commands/decorators.ts
+++ b/src/_internals/commands/decorators.ts
@@ -141,8 +141,10 @@ export function command(name: string | string[], config: RegisterConfig = {}): R
   const names = Array.isArray(name) ? name : [name]
 
   return createPropertyDecorator<CommandsRoot>(config.thisField ?? null, (commandsRoot, innerFunction, ...innerArgs) => {
-    // If the previous command was executable, register it.
-    // It means it wasn't registered because it could have been extended with other arguments.
+    /*
+     * If the previous command was executable, register it.
+     * It means it wasn't registered because it could have been extended with other arguments.
+     */
     if (config.isExecuteSubcommand && !commandsRoot.inExecute) {
       commandsRoot.register(true)
     }

--- a/src/_internals/datapack/BasePath.ts
+++ b/src/_internals/datapack/BasePath.ts
@@ -131,12 +131,12 @@ export class BasePathClass {
    * @param name The name of the function.
    * @param callback A callback containing the commands you want in the Minecraft Function.
    */
-  MCFunction = <T extends any[]>(
-    name: string, callback: (...args: T) => void, options?: McFunctionOptions,
-  ): McFunctionReturn<T> => {
+  MCFunction = <ARGS extends any[], RETURN extends void | Promise<void>>(
+    name: string, callback: (...args: ARGS) => RETURN, options?: McFunctionOptions,
+  ): McFunctionReturn<ARGS> => {
     const mcfunction = new MCFunctionClass(this.datapack, this.getName(name), callback, options ?? {})
 
-    this.datapack.rootFunctions.add(mcfunction as MCFunctionClass<any[]>)
+    this.datapack.rootFunctions.add(mcfunction as MCFunctionClass<any>)
 
     const returnFunction: any = mcfunction.call
     returnFunction.schedule = mcfunction.schedule

--- a/src/_internals/datapack/saveDatapack.ts
+++ b/src/_internals/datapack/saveDatapack.ts
@@ -300,7 +300,9 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
     await Promise.all(promises)
 
     if (!options.dryRun) {
-      console.log(chalk`{greenBright ✓ Successfully wrote datapack to "${rootPath}".} {gray (${promises.length.toLocaleString()} files - ${(Date.now() - start).toLocaleString()}ms)}`)
+      console.log(chalk`{greenBright ✓ Successfully wrote data pack to "${rootPath}".} {gray (${promises.length.toLocaleString()} files - ${(Date.now() - start).toLocaleString()}ms)}`)
+    } else {
+      console.log(chalk`{greenBright ✓ Successfully compiled data pack.} {gray (${(Date.now() - start).toLocaleString()}ms)}`)
     }
 
     return {

--- a/src/_internals/datapack/saveDatapack.ts
+++ b/src/_internals/datapack/saveDatapack.ts
@@ -239,7 +239,7 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
 
           // To display a function, we join their arguments. If we're in a console display, we put comments in gray.
           (func, consoleDisplay) => {
-            const repr = func.commands.map((command) => command.join(' ')).join('\n')
+            const repr = [...func.commands].map((command) => command.join(' ')).join('\n')
             if (consoleDisplay) {
               return repr.replace(/^#(.+)/gm, chalk.gray('#$1'))
             }

--- a/src/_internals/flow/Flow.ts
+++ b/src/_internals/flow/Flow.ts
@@ -4,6 +4,7 @@ import type {
 } from '@arguments'
 import type { CommandsRoot } from '@commands'
 import { Execute } from '@commands/implementations/Execute'
+import type { Datapack } from '@datapack'
 import type { CommandArgs } from '@datapack/minecraft'
 import type { ConditionClass } from '@variables'
 import { coordinatesParser } from '@variables'
@@ -28,12 +29,15 @@ type FlowStatementConfig = {
 export class Flow {
   private commandsRoot
 
+  private datapack
+
   arguments: CommandArgs
 
   constructor(
-    commandsRoot: CommandsRoot,
+    datapack: Datapack,
   ) {
-    this.commandsRoot = commandsRoot
+    this.datapack = datapack
+    this.commandsRoot = datapack.commandsRoot
     this.arguments = []
   }
 
@@ -142,8 +146,8 @@ export class Flow {
     const args = this.arguments.slice(1)
 
     // First, enter the callback
-    const callbackFunctionName = this.commandsRoot.Datapack.createEnterChildFunction(config.callbackName)
-    const callbackMcFunction = this.commandsRoot.Datapack.currentFunction
+    const callbackFunctionName = this.datapack.createEnterChildFunction(config.callbackName)
+    const callbackMcFunction = this.datapack.currentFunction
 
     // Add its commands
     callback()
@@ -157,7 +161,7 @@ export class Flow {
     }
 
     // Exit the callback
-    this.commandsRoot.Datapack.exitChildFunction()
+    this.datapack.exitChildFunction()
 
     // Put back the old arguments
     this.commandsRoot.arguments = previousArguments
@@ -179,7 +183,7 @@ export class Flow {
        * If you want to understand the reasons, see @vdvman1#9510 explanation =>
        * https://discordapp.com/channels/154777837382008833/154777837382008833/754985742706409492
        */
-      this.commandsRoot.Datapack.resources.deleteResource(callbackMcFunction.path, 'functions')
+      this.datapack.resources.deleteResource(callbackMcFunction.path, 'functions')
 
       if (callbackMcFunction.commands.length) {
         if (this.commandsRoot.arguments.length > 0) {
@@ -249,7 +253,7 @@ export class Flow {
 
   binaryMatch = (score: PlayerScore, minimum: number, maximum: number, callback: (num: number) => void) => {
     // First, specify we didn't find a match yet
-    const foundMatch = this.commandsRoot.Datapack.Variable(0)
+    const foundMatch = this.datapack.Variable(0)
 
     const callCallback = (num: number) => {
       this.if(this.and(score.equalTo(num), foundMatch.equalTo(0)), () => {
@@ -315,8 +319,8 @@ export class Flow {
       callback(to - from)
     }
 
-    const realStart = from instanceof PlayerScore ? from : this.commandsRoot.Datapack.Variable(from)
-    const realEnd = to instanceof PlayerScore ? to : this.commandsRoot.Datapack.Variable(to)
+    const realStart = from instanceof PlayerScore ? from : this.datapack.Variable(from)
+    const realEnd = to instanceof PlayerScore ? to : this.datapack.Variable(to)
 
     const iterations = realEnd.minus(realStart)
 
@@ -360,7 +364,7 @@ export class Flow {
       }
     }
 
-    const scoreTracker = from instanceof PlayerScore ? from : this.commandsRoot.Datapack.Variable(from)
+    const scoreTracker = from instanceof PlayerScore ? from : this.datapack.Variable(from)
 
     /*
      * If the callback does not use the "score" argument, we can directly set the real score
@@ -387,7 +391,7 @@ export class Flow {
     // eslint-disable-next-line no-shadow
     callback: (score: PlayerScore) => void,
   ) => {
-    const realScore = score instanceof PlayerScore ? score : this.commandsRoot.Datapack.Variable(score)
+    const realScore = score instanceof PlayerScore ? score : this.datapack.Variable(score)
     const realCondition = typeof condition === 'function' ? condition(realScore) : condition
 
     this.while(realCondition, () => {

--- a/src/_internals/flow/Flow.ts
+++ b/src/_internals/flow/Flow.ts
@@ -446,11 +446,11 @@ export class Flow {
     recursiveMatch(minimum, maximum)
   }
 
-  while = <R extends void | Promise<void>>(condition: ConditionClass | CombinedConditions, callback: () => R): R => {
+  private _while = <R extends void | Promise<void>>(condition: ConditionClass | CombinedConditions, callback: () => R, type: 'while' | 'doWhile'): R => {
     if (!isAsyncFunction(callback)) {
       this.flowStatement(callback, {
-        callbackName: 'while',
-        initialCondition: true,
+        callbackName: type,
+        initialCondition: type === 'while',
         loopCondition: true,
         condition,
       })
@@ -459,8 +459,8 @@ export class Flow {
     }
 
     const promise = this.flowStatementAsync(callback, {
-      callbackName: 'while',
-      initialCondition: true,
+      callbackName: type,
+      initialCondition: type === 'while',
       loopCondition: true,
       condition,
     })
@@ -475,14 +475,9 @@ export class Flow {
     } as any
   }
 
-  doWhile = (condition: ConditionClass | CombinedConditions, callback: () => void) => {
-    this.flowStatement(callback, {
-      callbackName: 'doWhile',
-      initialCondition: false,
-      loopCondition: true,
-      condition,
-    })
-  }
+  while = <R extends void | Promise<void>>(condition: ConditionClass | CombinedConditions, callback: () => R): R => this._while(condition, callback, 'while')
+
+  doWhile = <R extends void | Promise<void>>(condition: ConditionClass | CombinedConditions, callback: () => R): R => this._while(condition, callback, 'doWhile')
 
   binaryFor = (from: PlayerScore | number, to: PlayerScore |number, callback: (amount: number) => void, maximum = 128) => {
     if (typeof from === 'number' && typeof to === 'number') {

--- a/src/_internals/flow/conditions.ts
+++ b/src/_internals/flow/conditions.ts
@@ -39,8 +39,10 @@ export class CombinedConditions {
       return new CombinedConditions(this.commandsRoot, valuesWithoutOr, this.operator)
     }
 
-    // We have an OR operator. We need to transform it into an AND, using De Morgan's law:
-    // (A or B) = not (not A and not B)
+    /*
+     * We have an OR operator. We need to transform it into an AND, using De Morgan's law:
+     * (A or B) = not (not A and not B)
+     */
 
     // This corresponds to (not A, not B, not C)
     const newValues = valuesWithoutOr.map((value) => new CombinedConditions(this.commandsRoot, [value], 'not'))
@@ -117,7 +119,14 @@ export class CombinedConditions {
         callableExpression.push(this.operator === 'not' ? 'unless' : 'if', 'score', condition.toString(), 'matches', '1')
         return
       }
-      callableExpression.push(this.operator === 'not' ? 'unless' : 'if', ...value._toMinecraftCondition().value)
+
+      let conditionArgs = value._toMinecraftCondition().value
+      if (this.operator === 'not') {
+        // Invert the 1st argument, which is "if" or "unless"
+        const invertedOperator = conditionArgs[0] === 'if' ? 'unless' : 'if'
+        conditionArgs = [invertedOperator, ...value._toMinecraftCondition().value.slice(1)]
+      }
+      callableExpression.push(...conditionArgs)
     })
 
     return { requiredExpressions, callableExpression }

--- a/src/_internals/resources/MCFunctionClass.ts
+++ b/src/_internals/resources/MCFunctionClass.ts
@@ -6,7 +6,7 @@ import hash from 'object-hash'
 
 export type McFunctionOptions = {
   /**
-   * If true, then the function will only be created if it ??
+   * If true, then the function will only be created if it is called from another function.
    */
   lazy?: boolean
 

--- a/src/_internals/resources/MCFunctionClass.ts
+++ b/src/_internals/resources/MCFunctionClass.ts
@@ -43,7 +43,7 @@ export class MCFunctionClass<T extends any[], R extends void | Promise<void> = v
   alreadyInitializedParameters: Map<string, {
     mcFunction: FunctionResource,
     name: string,
-    result: R,
+    result: R | null, // Null mean the value isn't currently defined
   }>
 
   functionsFolderResource: FunctionResource
@@ -113,6 +113,9 @@ export class MCFunctionClass<T extends any[], R extends void | Promise<void> = v
     if (!existing) {
       // If it's the 1st time this mcfunction is called with these arguments, we create a new overload
       const { functionName, newFunction } = this.createFunctionOverload(args)
+
+      // We also set it as currently in initialization.
+      this.alreadyInitializedParameters.set(hashed, { name: functionName, mcFunction: newFunction, result: null })
 
       // Get the given tags
       let tags = this.options.tags ?? []

--- a/src/_internals/resources/Predicate.ts
+++ b/src/_internals/resources/Predicate.ts
@@ -19,7 +19,7 @@ export class Predicate extends Resource implements ConditionClass {
    */
   _toMinecraftCondition(): {value: any[]} {
     return {
-      value: ['predicate', this.name],
+      value: ['if', 'predicate', this.name],
     }
   }
 }

--- a/src/_internals/variables/PlayerScore.ts
+++ b/src/_internals/variables/PlayerScore.ts
@@ -31,7 +31,7 @@ function createVariable(datapack: Datapack, amountOrTargets: PlayersTarget, obje
   return anonymousScore
 }
 
-export class PlayerScore extends ComponentClass {
+export class PlayerScore extends ComponentClass implements ConditionClass {
   commandsRoot: CommandsRoot
 
   target: MultipleEntitiesArgument
@@ -55,6 +55,10 @@ export class PlayerScore extends ComponentClass {
       score: { name: this.target, objective: this.objective.name },
     }
   }
+
+  _toMinecraftCondition = () => ({
+    value: ['unless', 'score', this.target, this.objective.name, 'matches', 0],
+  })
 
   private unaryOperation(
     operation: 'add' | 'remove' | 'set',
@@ -127,7 +131,7 @@ export class PlayerScore extends ComponentClass {
    * Adds a constant amount to the entity's score.
    *
    * @param amount The amount to add to the entity's score.
-  */
+   */
   add(amount: number): this
 
   /**
@@ -154,23 +158,23 @@ export class PlayerScore extends ComponentClass {
    * Substract a constant amount from the entity's score.
    *
    * @param amount The amount to substract to the entity's score.
-  */
+   */
   remove(amount: number): this
 
   /**
-  * Substract other target's scores from the current entity's score.
-  *
-  * @param targets The targets to get the scores from
-  *
-  * @param objective The related objective. If not specified, default to the same objective as the current target.
-  */
+   * Substract other target's scores from the current entity's score.
+   *
+   * @param targets The targets to get the scores from
+   *
+   * @param objective The related objective. If not specified, default to the same objective as the current target.
+   */
   remove(targets: MultipleEntitiesArgument, objective?: ObjectiveArgument): this
 
   /**
-  * Substract other entities's scores from the current entity's score.
-  *
-  * @param targetScore The target to get the scores from
-  */
+   * Substract other entities's scores from the current entity's score.
+   *
+   * @param targetScore The target to get the scores from
+   */
   remove(targetScore: PlayerScore): this
 
   remove(...args: OperationArguments) {
@@ -437,13 +441,13 @@ export class PlayerScore extends ComponentClass {
 
     if (typeof args[0] === 'number') {
       return {
-        _toMinecraftCondition: () => ({ value: ['score', playerScore.target, playerScore.objective, 'matches', matchesRange] }),
+        _toMinecraftCondition: () => ({ value: ['if', 'score', playerScore.target, playerScore.objective, 'matches', matchesRange] }),
       }
     }
 
     const endArgs = args[1] ? args : [args[0]]
     return {
-      _toMinecraftCondition: () => ({ value: ['score', playerScore.target, playerScore.objective, operator, ...endArgs] }),
+      _toMinecraftCondition: () => ({ value: ['if', 'score', playerScore.target, playerScore.objective, operator, ...endArgs] }),
     }
   }
 

--- a/src/_internals/variables/Selector.ts
+++ b/src/_internals/variables/Selector.ts
@@ -106,28 +106,40 @@ export type SelectorProperties<MustBeSingle extends boolean, MustBePlayer extend
   /** Select all targets that match the specified predicate. */
   predicate?: string | Predicate | (Predicate | string)[]
 } & ({} | {
-  /** Define a position on the X-axis in the world the selector starts at,
-   * for use with the `distance` argument or the volume arguments, `dx`, `dy` and `dz`. */
+  /**
+   * Define a position on the X-axis in the world the selector starts at,
+   * for use with the `distance` argument or the volume arguments, `dx`, `dy` and `dz`.
+   */
   x: number
 
-  /** Define a position on the Y-axis in the world the selector starts at,
-   * for use with the `distance` argument or the volume arguments, `dx`, `dy` and `dz`. */
+  /**
+   * Define a position on the Y-axis in the world the selector starts at,
+   * for use with the `distance` argument or the volume arguments, `dx`, `dy` and `dz`.
+   */
   y: number
 
-  /** Define a position on the Z-axis in the world the selector starts at,
-   * for use with the `distance` argument or the volume arguments, `dx`, `dy` and `dz`. */
+  /**
+   * Define a position on the Z-axis in the world the selector starts at,
+   * for use with the `distance` argument or the volume arguments, `dx`, `dy` and `dz`.
+   */
   z: number
 }) & ({} | {
-  /** Filter target selection based on their x-difference, from some point,
-   * as measured from the closest corner of the entities' hitboxes */
+  /**
+   * Filter target selection based on their x-difference, from some point,
+   * as measured from the closest corner of the entities' hitboxes
+   */
   dx: number
 
-  /** Filter target selection based on their y-difference, from some point,
-   * as measured from the closest corner of the entities' hitboxes */
+  /**
+   * Filter target selection based on their y-difference, from some point,
+   * as measured from the closest corner of the entities' hitboxes
+   */
   dy: number
 
-  /** Filter target selection based on their z-difference, from some point,
-   * as measured from the closest corner of the entities' hitboxes */
+  /**
+   * Filter target selection based on their z-difference, from some point,
+   * as measured from the closest corner of the entities' hitboxes
+   */
   dz: number
 }) & (
   MustBeSingle extends true ? { limit: 0 | 1 } : { limit?: number }
@@ -228,7 +240,7 @@ export class SelectorClass<IsSingle extends boolean = false, IsPlayer extends bo
   }
 
   _toMinecraftCondition(this: SelectorClass<IsSingle, IsPlayer>) {
-    return { value: ['entity', this] }
+    return { value: ['if', 'entity', this] }
   }
 
   toString() {

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,7 +3,7 @@ import { datapack } from './_internals'
 export { SandstoneConfig } from './_internals/datapack/Datapack'
 
 export const {
-  save: savePack, BasePath,
+  save: savePack, BasePath, sleep,
 } = datapack
 
 export const {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,14 +1,14 @@
 import { say, tellraw } from 'src/commands'
 import { MCFunction, sleep, savePack } from 'src/core'
 
-MCFunction('display_message', async () => {
-  say('ho')
-  await sleep(10)
+MCFunction('council', async () => {
+  tellraw('@a', '[Aragorn] - You have my sword.')
+  await sleep(10) // sleep 10 ticks, half a second.
 
-  say('oops I slept too much')
-  await sleep(12)
+  tellraw('@a', '[Legolas] - And my bow.')
+  await sleep('1s') // sleep 1 second
 
-  say('once again')
+  tellraw('@a', '[Gimly] - AND MY AXE!')
 })
 
 savePack('My Datapack', {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,20 +1,20 @@
-import { tellraw } from 'src/commands'
-import { MCFunction, Predicate, savePack } from 'src/core'
+import { say, tellraw } from 'src/commands'
+import { MCFunction, sleep, savePack } from 'src/core'
 
-MCFunction('display_message', () => {
-  tellraw('@a', [
-    ['hi'],
-    '\n========= Congratulations! =========\n\n',
-    { text: ' Sandstone', color: 'gold', bold: true }, ' is ', { text: 'successfully installed.\n\n', color: 'green' },
-    ' Add files to the ', { text: 'src', underlined: true }, ' folder\n',
-    ' and start creating your data pack!\n',
-    '==============', { text: '🏹', color: '#D2691E' }, { text: '⚔', color: '#45ACA5' }, { text: '⛏', color: '#FFD700' }, '==============',
-  ])
-}, {
-  runOnLoad: true,
+const disp = MCFunction('display_message', async () => {
+  say('ho')
+  await sleep(10)
+  say('oops I slept too much')
+})
+
+MCFunction('test', () => {
+  say('b4')
+  disp()
+  say('aftR')
 })
 
 savePack('My Datapack', {
   verbose: true,
   world: 'Crea1_15',
+  dryRun: true,
 })

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,16 +1,14 @@
 import { say, tellraw } from 'src/commands'
 import { MCFunction, sleep, savePack } from 'src/core'
 
-const disp = MCFunction('display_message', async () => {
+MCFunction('display_message', async () => {
   say('ho')
   await sleep(10)
-  say('oops I slept too much')
-})
 
-MCFunction('test', () => {
-  say('b4')
-  disp()
-  say('aftR')
+  say('oops I slept too much')
+  await sleep(12)
+
+  say('once again')
 })
 
 savePack('My Datapack', {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,18 +1,15 @@
-import { say, tellraw } from 'src/commands'
-import { MCFunction, sleep, savePack } from 'src/core'
+import { comment, say } from 'src/commands'
+import {
+  MCFunction, savePack, _,
+} from 'src/core'
+import { Variable } from 'src/variables'
 
-MCFunction('council', async () => {
-  tellraw('@a', '[Aragorn] - You have my sword.')
-  await sleep(10) // sleep 10 ticks, half a second.
-
-  tellraw('@a', '[Legolas] - And my bow.')
-  await sleep('1s') // sleep 1 second
-
-  tellraw('@a', '[Gimly] - AND MY AXE!')
+const myFunc = MCFunction('recursive', () => {
+  comment('Hey!')
+  myFunc()
 })
 
 savePack('My Datapack', {
   verbose: true,
   world: 'Crea1_15',
-  dryRun: true,
 })


### PR DESCRIPTION
This pull request adds the ability to await a `sleep` function, which internally uses `/schedule` to allow MCFunctions to run delayed commands.
The syntax is `await sleep(10) / await sleep('1s')`.

Since this effect needs to work flawlessly in every Sandstone abstraction, this PR also adds:
- Asynchronous while & doWhile statements
- Asynchronous if/else if/else statements