### PR TITLE
Added if/else inlining, and some options

### DIFF
--- a/src/_internals/arguments/basics.ts
+++ b/src/_internals/arguments/basics.ts
@@ -1,3 +1,4 @@
+import type { LiteralUnion } from '@/generalTypes'
 import type { MultipleEntitiesArgument } from '@arguments'
 
 export type AXES = 'x' | 'xy' | 'yz' | 'xz' | 'xyz'
@@ -25,6 +26,8 @@ export class _ShowAlias {
 }
 
 export type MessageOrSelector = (string | MultipleEntitiesArgument | number) | _ShowAlias
+
+export type TimeArgument = number | LiteralUnion<'1t' | '1s' | '1d'>
 
 export type TAG_TYPES = 'blocks' | 'entity_types' | 'fluids' | 'functions' | 'items'
 

--- a/src/_internals/commands/implementations/Schedule.ts
+++ b/src/_internals/commands/implementations/Schedule.ts
@@ -5,6 +5,7 @@ import { TagClass } from '@resources'
 import { FunctionCommand } from './Function'
 
 import type { LiteralUnion } from '@/generalTypes'
+import type { TimeArgument } from '@arguments'
 import type { MCFunctionInstance } from '@datapack/Datapack'
 
 export class Schedule extends Command {
@@ -80,7 +81,7 @@ export class Schedule extends Command {
        * `replace` simply replaces the current function's schedule time. `append` allows multiple schedules to exist at different times.
        * If unspecified, defaults to `replace`.
        */
-      (functionName: string | TagClass<'functions'>, delay: number | LiteralUnion<'1t' | '1s' | '1d'>, type?: 'append' | 'replace') => void
+      (functionName: string | TagClass<'functions'>, delay: TimeArgument, type?: 'append' | 'replace') => void
     ) & (
       /**
        * Delays the execution of a function. Executes the function after specified amount of time passes.
@@ -107,7 +108,7 @@ export class Schedule extends Command {
        * `replace` simply replaces the current function's schedule time. `append` allows multiple schedules to exist at different times.
        * If unspecified, defaults to `replace`.
        */
-      (mcFunction: MCFunctionInstance, delay: number | LiteralUnion<'1t' | '1s' | '1d'>, type?: 'append' | 'replace') => void
+      (mcFunction: MCFunctionInstance, delay: TimeArgument, type?: 'append' | 'replace') => void
     )
   ) = (func: string | MCFunctionInstance | TagClass<'functions'>, delay: unknown, type?: 'append' | 'replace') => {
     if (typeof func === 'string' || func instanceof TagClass) {

--- a/src/_internals/commands/implementations/Time.ts
+++ b/src/_internals/commands/implementations/Time.ts
@@ -2,6 +2,7 @@ import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
 import type { LiteralUnion } from '@/generalTypes'
+import type { TimeArgument } from '@arguments'
 
 /**
  * Changes or queries the world's game time.
@@ -16,7 +17,7 @@ export class Time extends Command {
    * - `t` (default and omitable): a single gametick; the default unit.
    */
   @command(['time', 'add'], { isRoot: true })
-  add = (time: number | LiteralUnion<'1t' | '1s' | '1d'>) => {}
+  add = (time: TimeArgument) => {}
 
   /**
    * Queries current time.
@@ -38,5 +39,5 @@ export class Time extends Command {
    * - `t` (default and omitable): a single gametick; the default unit.
    */
   @command(['time', 'set'], { isRoot: true })
-  set = (time: number | LiteralUnion<'1t' | '1s' | '1d'> | LiteralUnion<'day' | 'night' | 'noon' | 'midnight'>) => {}
+  set = (time: TimeArgument | LiteralUnion<'day' | 'night' | 'noon' | 'midnight'>) => {}
 }

--- a/src/_internals/datapack/Datapack.ts
+++ b/src/_internals/datapack/Datapack.ts
@@ -9,7 +9,7 @@ import { ResourcesTree } from './resourcesTree'
 import { saveDatapack } from './saveDatapack'
 
 import type { LiteralUnion } from '@/generalTypes'
-import type { JsonTextComponent, OBJECTIVE_CRITERION } from '@arguments'
+import type { JsonTextComponent, OBJECTIVE_CRITERION, TimeArgument } from '@arguments'
 import type { MCFunctionClass } from '@resources'
 import type { ObjectiveClass } from '@variables'
 import type { BasePathOptions } from './BasePath'
@@ -60,7 +60,15 @@ export interface SandstoneConfig {
   packUid: string
 
   /** All the options to save the data pack. */
-  saveOptions: ({
+  saveOptions: {
+    /**
+     * A custom handler for saving files. If specified, files won't be saved anymore, you will have to handle that yourself.
+     */
+    customFileHandler?: SaveOptions['customFileHandler']
+
+    /** The indentation to use for all JSON & MCMeta files. This argument is the same than `JSON.stringify` 3d argument. */
+    indentation?: string | number
+  } & ({
     /**
      * The world to save the data pack in.
      *
@@ -81,12 +89,7 @@ export interface SandstoneConfig {
      * Incompatible with `root` and `world`.
      */
     path: string
-  }) & {
-    /**
-     * A custom handler for saving files. If specified, files won't be saved anymore, you will have to handle that yourself.
-     */
-    customFileHandler?: SaveOptions['customFileHandler']
-  }
+  })
 
   /** Some scripts that can run at defined moments. */
   scripts?: {
@@ -104,7 +107,7 @@ export interface SandstoneConfig {
 export interface MCFunctionInstance<RETURN extends (void | Promise<void>) = (void | Promise<void>)> {
   (): RETURN
 
-  schedule: (delay: number | LiteralUnion<'1t' | '1s' | '1d'>, type?: 'append' | 'replace') => void
+  schedule: (delay: TimeArgument, type?: 'append' | 'replace') => void
 
   clearSchedule: () => void
 
@@ -451,7 +454,7 @@ export default class Datapack {
     } as ResourceOnlyTypeMap[T])
   }
 
-  sleep = (delay: number | LiteralUnion<'1t' | '1s' | '1d'>): PromiseLike<void> => {
+  sleep = (delay: TimeArgument): PromiseLike<void> => {
     const SLEEP_CHILD_NAME = '__sleep'
 
     if (!this.currentFunction) {

--- a/src/_internals/datapack/minecraft.ts
+++ b/src/_internals/datapack/minecraft.ts
@@ -1,6 +1,3 @@
-/**
- * A MCFunction's name has at least 2 components: a namespace, then the different folders up to the function itself.
- */
 export type CommandArgs = any[]
 
 export function toMCFunctionName(functionName: readonly string[]): string {

--- a/src/_internals/datapack/saveDatapack.ts
+++ b/src/_internals/datapack/saveDatapack.ts
@@ -16,8 +16,6 @@ import type {
   ResourceTypes,
 } from './resourcesTree'
 
-type ExtendedResourceTypes = ResourceTypes
-
 type SaveFileObject = {
   packType: 'datapack'
   type: ResourceTypes | 'raw'
@@ -71,6 +69,9 @@ export type SaveOptions = {
    * A custom handler for saving files. If specified, files won't be saved anymore, you will have to handle that yourself.
    */
   customFileHandler?: (fileInfo: SaveFileObject) => Promise<void> | void
+
+  /** The indentation to use for all JSON & MCMeta files. This argument is the same than `JSON.stringify` 3d argument. */
+  indentation?: string | number
 } & (
     {
       /**
@@ -182,6 +183,8 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
     return func(info)
   }
 
+  const indentation = options.indentation ?? 2
+
   try {
     const start = Date.now()
 
@@ -226,7 +229,7 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
         packType: 'datapack',
         type: 'raw',
         resource: packMcMeta,
-        content: JSON.stringify(packMcMeta, null, 2),
+        content: JSON.stringify(packMcMeta, null, indentation),
         rootPath,
         relativePath: 'pack.mcmeta',
         saveOptions: options,
@@ -256,7 +259,7 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
       for (const t of n.tags.values()) {
         promises.push(...saveResource(
           rootPath, 'tags', t, options,
-          (r) => JSON.stringify({ replace: r.replace ?? false, values: r.values }, null, 2),
+          (r) => JSON.stringify({ replace: r.replace ?? false, values: r.values }, null, indentation),
           (namespace, folders, fileName) => `Tag[${folders[0]}] ${namespace}:${[...folders.slice(1), fileName].join('/')}`,
         ))
       }
@@ -265,7 +268,7 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
       for (const a of n.advancements.values()) {
         promises.push(...saveResource(
           rootPath, 'advancements', a, options,
-          (r) => JSON.stringify(r.advancement, null, 2),
+          (r) => JSON.stringify(r.advancement, null, indentation),
           (namespace, folders, fileName) => `Avancement ${namespace}:${[...folders, fileName].join('/')}`,
         ))
       }
@@ -274,7 +277,7 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
       for (const p of n.predicates.values()) {
         promises.push(...saveResource(
           rootPath, 'predicates', p, options,
-          (r) => JSON.stringify(r.predicate, null, 2),
+          (r) => JSON.stringify(r.predicate, null, indentation),
           (namespace, folders, fileName) => `Predicate ${namespace}:${[...folders, fileName].join('/')}`,
         ))
       }
@@ -283,7 +286,7 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
       for (const l of n.loot_tables.values()) {
         promises.push(...saveResource(
           rootPath, 'loot_tables', l, options,
-          (r) => JSON.stringify(r.lootTable, null, 2),
+          (r) => JSON.stringify(r.lootTable, null, indentation),
           (namespace, folders, fileName) => `Loot table ${namespace}:${[...folders, fileName].join('/')}`,
         ))
       }
@@ -292,7 +295,7 @@ export async function saveDatapack(resources: ResourcesTree, name: string, optio
       for (const r of n.recipes.values()) {
         promises.push(...saveResource(
           rootPath, 'recipes', r, options,
-          (resource) => JSON.stringify(resource.recipe, null, 2),
+          (resource) => JSON.stringify(resource.recipe, null, indentation),
           (namespace, folders, fileName) => `Recipe ${namespace}:${[...folders, fileName].join('/')}`,
         ))
       }

--- a/src/_internals/variables/PlayerScore.ts
+++ b/src/_internals/variables/PlayerScore.ts
@@ -1,4 +1,5 @@
 import { ComponentClass } from '@variables/abstractClasses'
+import { rangeParser } from '@variables/parsers'
 
 import type {
   COMPARISON_OPERATORS, JsonTextComponent, MultipleEntitiesArgument, ObjectiveArgument, OPERATORS,
@@ -6,6 +7,7 @@ import type {
 import type { CommandsRoot } from '@commands'
 import type { Datapack } from '@datapack'
 import type { ConditionClass } from '@variables/abstractClasses'
+import type { Range } from '..'
 import type { ObjectiveClass } from './Objective'
 
 type PlayersTarget = number | MultipleEntitiesArgument
@@ -103,6 +105,13 @@ export class PlayerScore extends ComponentClass implements ConditionClass {
   }
 
   /** INLINE OPERATORS */
+  /**
+   * Reset the entity's score.
+   */
+  reset = () => {
+    this.commandsRoot.scoreboard.players.reset(this.target, this.objective)
+  }
+
   /**
    * Set the entity's score to a given amount.
    *
@@ -588,4 +597,13 @@ export class PlayerScore extends ComponentClass implements ConditionClass {
   equalTo(...args: OperationArguments) {
     return this.comparison('=', args[0].toString(), args)
   }
+
+  /**
+   * Check if the current score matches a certain range.
+   *
+   * @param range The range to compare the current score against.
+   */
+  matches = (range: Range) => ({
+    _toMinecraftCondition: () => ({ value: ['if', 'score', this.target, this.objective, 'matches', rangeParser(range)] }),
+  })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,5 +2,5 @@ export * from './_internals/arguments'
 export { MCFunctionInstance } from './_internals/datapack/Datapack'
 export { LiteralUnion } from './_internals/generalTypes'
 export {
-  AdvancementClass, LootTableClass, MCFunctionClass, MCFunctionOptions, PredicateClass, RecipeClass, ResourceClass, TagClass,
+  AdvancementClass, LootTableClass, MCFunctionOptions, PredicateClass, RecipeClass, ResourceClass, TagClass,
 } from './_internals/resources'


### PR DESCRIPTION
Changelog:
- Added `if/else` inlining & optimization ([SAND-4]). Now:
  + Single `_.if` won't create the whole boilerplate anymore.
  + 1-line `_.if` and `_.elseIf` will be inlined
- Added the `runEach` option for `MCFunction`, allowing a function to run in loop with a given delay between each call. [SAND-5]
- Added an `indentation` option for `savePack`, modifying the indentation used for all JSON & MCMeta files. [SAND-2]

[SAND-4]: https://themrzz.atlassian.net/browse/SAND-4
[SAND-5]: https://themrzz.atlassian.net/browse/SAND-5
[SAND-2]: https://themrzz.atlassian.net/browse/SAND-2