### PR TITLE
Fixed two breaking bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandstone",
   "description": "Sandstone, a Typescript library for Minecraft datapacks.",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "author": "TheMrZZ - Florian ERNST",
   "bugs": {
     "url": "https://github.com/TheMrZZ/sandstone/issues"

--- a/src/_internals/arguments/basics.ts
+++ b/src/_internals/arguments/basics.ts
@@ -14,7 +14,7 @@ export type GAMEMODES = 'survival' | 'creative' | 'adventure' | 'spectator'
 
 export type DIFFICULTIES = 'easy' | 'normal' | 'hard' | 'peaceful'
 
-export type OPERATORS = '=' | '+=' | '-=' | '/=' | '*=' | '%=' | '<=' | '>=' | '<>'
+export type OPERATORS = '=' | '+=' | '-=' | '/=' | '*=' | '%=' | '<' | '>' | '<>'
 
 export type COMPARISON_OPERATORS = '<' | '<=' | '=' | '>=' | '>'
 

--- a/src/_internals/variables/Selector.ts
+++ b/src/_internals/variables/Selector.ts
@@ -313,7 +313,7 @@ export function SelectorCreator(target: '@a', selectorArguments: Omit<SingleSele
 export function SelectorCreator(target: '@a', selectorArguments?: Omit<AnySelectorProperties, 'type'>): SelectorClass<false, true>
 export function SelectorCreator(target: '@e', selectorArguments: SinglePlayerSelectorProperties): SelectorClass<true, true>
 export function SelectorCreator(target: '@e', selectorArguments: SingleSelectorProperties): SelectorClass<true, false>
-export function SelectorCreator(target: '@e', selectorArguments: AnySelectorProperties): SelectorClass<false, false>
+export function SelectorCreator(target: '@e', selectorArguments?: AnySelectorProperties): SelectorClass<false, false>
 
 export function SelectorCreator<T extends boolean, U extends boolean>(this: CommandsRoot, target: '@s' | '@p' | '@r' | '@a' | '@e', selectorArguments?: SelectorProperties<T, U>): SelectorClass<T, U> {
   return new SelectorClass(this, target, selectorArguments)


### PR DESCRIPTION
Fixed two breaking bugs:
- `Selector` wasn't taking `'@e'` as an argument
- Scoreboard players operation were taking `<=` and `>=` as operation, instead of `<` and `>`