### PR TITLE
0.9.0 - Several improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandstone",
   "description": "Sandstone, a Typescript library for Minecraft datapacks.",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "author": "TheMrZZ - Florian ERNST",
   "bugs": {
     "url": "https://github.com/TheMrZZ/sandstone/issues"

--- a/src/_internals/commands/implementations/Advancement.ts
+++ b/src/_internals/commands/implementations/Advancement.ts
@@ -3,6 +3,7 @@ import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
 import type { MultiplePlayersArgument } from '@arguments'
+import type { AdvancementClass } from '@resources'
 
 class AdvancementArguments extends Command {
   /** Adds or removes all loaded advancements. */
@@ -19,7 +20,7 @@ class AdvancementArguments extends Command {
    * If specified, the command refers to merely the criterion and not the entire advancement.
    */
   @command('only', { isRoot: false, executable: true })
-  only = (advancement: string, criterion?: string) => { }
+  only = (advancement: string | AdvancementClass, criterion?: string) => { }
 
   /**
    * Adds or removes an advancement and all its children advancements.
@@ -34,7 +35,7 @@ class AdvancementArguments extends Command {
    * @param advancement Specifies a valid namespaced id of the advancement to target.
    */
   @command('from', { isRoot: false, executable: true })
-  from = (advancement: string) => { }
+  from = (advancement: string | AdvancementClass) => { }
 
   /**
    * Specifies an advancement, and adds or removes all its parent advancements, and all its children advancements.
@@ -47,7 +48,7 @@ class AdvancementArguments extends Command {
    * @param advancement Specifies a valid namespaced id of the advancement to target.
    */
   @command('through', { isRoot: false, executable: true })
-  through = (advancement: string) => { }
+  through = (advancement: string | AdvancementClass) => { }
 
   /**
    * Adds or removes an advancement and all its parent advancements until the root for addition/removal.
@@ -60,7 +61,7 @@ class AdvancementArguments extends Command {
    * @param advancement Specifies a valid namespaced id of the advancement to target.
    */
   @command('until', { isRoot: false, executable: true })
-  until = (advancement: string) => { }
+  until = (advancement: string | AdvancementClass) => { }
 }
 
 /** Gives or takes an advancement from one or more players. */

--- a/src/_internals/resources/MCFunctionClass.ts
+++ b/src/_internals/resources/MCFunctionClass.ts
@@ -4,6 +4,7 @@ import type { LiteralUnion } from '@/generalTypes'
 import type { TimeArgument } from '@arguments'
 import type { Datapack } from '@datapack'
 import type { FunctionResource } from '@datapack/resourcesTree'
+import type { TagClass } from './Tag'
 
 export type MCFunctionOptions = {
   /**
@@ -30,7 +31,7 @@ export type MCFunctionOptions = {
   /**
    * The function tags to put this function in.
    */
-  tags?: readonly string[]
+  tags?: readonly (string | TagClass<'functions'>)[]
 } & (
   {
     /**
@@ -135,7 +136,11 @@ export class MCFunctionClass<R extends void | Promise<void> = void | Promise<voi
     }
 
     for (const tag of tags) {
-      this.datapack.addFunctionToTag(this.name, tag)
+      if (typeof tag === 'string') {
+        this.datapack.addFunctionToTag(this.name, tag)
+      } else {
+        tag.values.push(this.name)
+      }
     }
 
     const previousFunction = this.datapack.currentFunction

--- a/src/_internals/resources/MCFunctionClass.ts
+++ b/src/_internals/resources/MCFunctionClass.ts
@@ -44,7 +44,9 @@ export type MCFunctionOptions = {
      *
      * If `runOnLoad` is unspecified or `true`, then it will run on load too.
      *
-     * If `runOnLoad` is `false`, when the data pack loads, it will wait the given time until the first execution.
+     * If `runOnLoad` is `false`, you will have to manually start it.
+     *
+     * You can stop the automatic scheduling by running `theFunction.clearSchedule()`.
      *
      * @example
      *
@@ -119,9 +121,6 @@ export class MCFunctionClass<R extends void | Promise<void> = void | Promise<voi
       if (this.options.runOnLoad !== false) {
         // If run on load, call it directly
         this.datapack.initCommands.push(['function', this.name])
-      } else {
-        // If not, schedule it
-        this.datapack.initCommands.push(['schedule', 'function', this.name, runEachDelay, 'append'])
       }
     } else {
       // If runEachTick is specified, add to minecraft:tick

--- a/src/_internals/resources/Tag.ts
+++ b/src/_internals/resources/Tag.ts
@@ -45,7 +45,7 @@ export class TagClass<TYPE extends TAG_TYPES> extends ResourceClass {
 
   readonly values: TagSingleValue<string>[]
 
-  constructor(datapack: Datapack, type: TYPE, name: string, values: readonly TagSingleValue<HintedTagStringType<TYPE>>[], replace?: boolean) {
+  constructor(datapack: Datapack, type: TYPE, name: string, values: readonly TagSingleValue<HintedTagStringType<TYPE>>[] = [], replace?: boolean) {
     super(datapack, name)
 
     this.type = type


### PR DESCRIPTION
Changelog:
- `Tag` values now default to `[]`
- `MCFunction` `tags` arguments now accepts Sandstone function tags
- `/advancement` now accepts Sandstone advancements
- On `MCFunction`, changed `runEach` behavior when `runOnLoad` is false. Now, the function won't be ran at all, and the user will have to manually run it.