### PR TITLE
Several fixes - v0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandstone",
   "description": "Sandstone, a Typescript library for Minecraft datapacks.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "TheMrZZ - Florian ERNST",
   "bugs": {
     "url": "https://github.com/TheMrZZ/sandstone/issues"

--- a/src/_internals/arguments/resources/advancement.ts
+++ b/src/_internals/arguments/resources/advancement.ts
@@ -6,7 +6,7 @@ import type { AdvancementClass } from '@resources'
 import type { AdvancementTriggers } from './AdvancementTriggers'
 
 /** A representation of a Minecraft advancement. */
-export interface AdvancementType<CRITERIA_NAMES extends string> {
+export interface AdvancementType<CRITERIA_NAMES extends string = string> {
   /** The optional display data. */
   display?: {
     /** The data for the icon. */

--- a/src/_internals/datapack/BasePath.ts
+++ b/src/_internals/datapack/BasePath.ts
@@ -190,7 +190,7 @@ export class BasePathClass<N extends (undefined | string), D extends (undefined 
   Predicate = (name: string, predicate: PredicateType) => new PredicateClass(this.datapack, this.getName(name), predicate)
 
   /** Create a tag. */
-  Tag = <T extends TAG_TYPES>(type: T, name: string, values: TagSingleValue<HintedTagStringType<T>>[], replace?: boolean) => new TagClass(this.datapack, type, this.getName(name), values, replace)
+  Tag = <T extends TAG_TYPES>(type: T, name: string, values: TagSingleValue<HintedTagStringType<T>>[] = [], replace?: boolean) => new TagClass(this.datapack, type, this.getName(name), values, replace)
 
   /**
    * Create a loot table.

--- a/src/_internals/datapack/Datapack.ts
+++ b/src/_internals/datapack/Datapack.ts
@@ -19,6 +19,13 @@ import type {
 } from './resourcesTree'
 import type { SaveOptions } from './saveDatapack'
 
+type ScriptArguments = {
+  /** The name of the data pack. */
+  dataPackName: string,
+  /** The destination folder of the data pack. */
+  destination: string,
+}
+
 export interface SandstoneConfig {
   /**
    * The default namespace for the data pack.
@@ -94,13 +101,13 @@ export interface SandstoneConfig {
   /** Some scripts that can run at defined moments. */
   scripts?: {
     /** A script running before Sandstone starts importing source files. */
-    beforeAll?: () => (void | Promise<void>)
+    beforeAll?: (options: ScriptArguments) => (void | Promise<void>)
 
     /** A script running before Sandstone starts saving the files. */
-    beforeSave?: () => (void | Promise<void>)
+    beforeSave?: (options: ScriptArguments) => (void | Promise<void>)
 
     /** A script running after Sandstone saved all files. */
-    afterAll?: () => (void | Promise<void>)
+    afterAll?: (options: ScriptArguments) => (void | Promise<void>)
   }
 }
 

--- a/src/_internals/variables/PlayerScore.ts
+++ b/src/_internals/variables/PlayerScore.ts
@@ -410,7 +410,7 @@ export class PlayerScore extends ComponentClass implements ConditionClass {
 
   dividedBy(...args: OperationArguments): PlayerScore {
     const anonymousScore = createVariable(this.commandsRoot.Datapack, this.target, this.objective)
-    anonymousScore.binaryOperation('*=', ...args)
+    anonymousScore.binaryOperation('/=', ...args)
     return anonymousScore
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export * from './_internals/arguments'
+export { BasePathClass, BasePathOptions } from './_internals/datapack/BasePath'
 export { MCFunctionInstance } from './_internals/datapack/Datapack'
 export { LiteralUnion } from './_internals/generalTypes'
 export {


### PR DESCRIPTION
Changelog:
- Fixed playerScore.dividedBy using `*=` and not `/=`
- Set default Tag value to `[]`
- Set default AdvancementType generic criteria names to `string`
- Added BasePathClass & BasePathOptions to exports
- Added 2 arguments for scripts: `destination` & `dataPackName` 