### PR TITLE
Changes in execute.if & data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandstone",
   "description": "Sandstone, a Typescript library for Minecraft datapacks.",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "author": "TheMrZZ - Florian ERNST",
   "bugs": {
     "url": "https://github.com/TheMrZZ/sandstone/issues"

--- a/src/commands/CommandsRoot.ts
+++ b/src/commands/CommandsRoot.ts
@@ -184,8 +184,8 @@ export class CommandsRoot {
     })
   }
 
-  // experience command //
-  experience = new Experience(this)
+  // experience command (aliased as xp) //
+  xp = new Experience(this)
 
   // fill command //
   fill = (new Fill(this)).fill
@@ -473,7 +473,7 @@ export class CommandsRoot {
   // team command //
   team = new Team(this)
 
-  // teammessage command //
+  // teammsg command (aliased to tm) //
   /**
    * Specifies a message to send to team.
    *
@@ -484,13 +484,13 @@ export class CommandsRoot {
    *
    * At least one message is necesarry.
    */
-  @command('teammessage', { isRoot: true })
-  teammessage = (...messages: AtLeastOne<MessageOrSelector>) => { }
+  @command('tm', { isRoot: true })
+  tm = (...messages: AtLeastOne<MessageOrSelector>) => { }
 
-  // teleport command //
-  teleport = (new Teleport(this)).teleport
+  // teleport command (aliased to tp) //
+  tp = (new Teleport(this)).tp
 
-  // tell command //
+  // msg command (aliased to w) //
   /**
    * Sends a private message to one or more players.
    * @param targets Specifies the player(s) to send the message to.
@@ -499,8 +499,8 @@ export class CommandsRoot {
    * The game replaces entity selectors in the message with the list of selected entities' names,
    * which is formatted as "name1 and name2" for two entities, or "name1, name2, ... and namen" for n entities.
    */
-  @command('tell', { isRoot: true })
-  tell = (targets: MultiplePlayersArgument, ...messages: AtLeastOne<MessageOrSelector>) => { }
+  @command('w', { isRoot: true })
+  w = (targets: MultiplePlayersArgument, ...messages: AtLeastOne<MessageOrSelector>) => { }
 
   // tellraw command //
   @command('tellraw', { isRoot: true, parsers: { '1': (msg) => new JsonTextComponentClass(msg) } })
@@ -519,16 +519,27 @@ export class CommandsRoot {
 
   worldborder = new WorldBorder(this)
 
-  // / ALIAS COMMANDS ///
+  // / ALIAS COMMANDS. ///
+
+  /*
+   * In Sandstone, data pack is considered a byproduct of the compilation,
+   * so the shorter aliases will always be the compiled result.
+   */
+
+  // tell command //
+  tell = this.w
+
+  // teammsg command //
+  teammsg = this.tm
+
+  // teleport command //
+  teleport = this.tp
 
   // msg command //
-  msg: CommandsRoot['tell'] = (...args) => this.tell(...args)
+  msg = this.w
 
-  // w command //
-  w: CommandsRoot['tell'] = (...args) => this.tell(...args)
-
-  // xp command //
-  xp: CommandsRoot['experience'] = this.experience
+  // experience command //
+  experience = this.xp
 }
 
 export default CommandsRoot

--- a/src/commands/implementations/Data.ts
+++ b/src/commands/implementations/Data.ts
@@ -75,32 +75,44 @@ class DataMerge extends Command {
 }
 
 class DataModifyValues extends Command {
-  /**
-   * Modify with the NBT of a block at the given position.
-   *
-   * @param sourcePosition The coordinates of the block to modify the NBT with.
-   * @param sourcePath The path of the NBT to modify with.
-   */
   @command(['from', 'block'], { parsers: { '0': coordinatesParser } })
-  fromBlock = (sourcePosition: Coordinates, sourcePath: string) => { }
+  private fromBlock = (...args: unknown[]) => { }
 
-  /**
-   * Modify with the NBT of a given entity.
-   *
-   * @param source The entity to modify the NBT with.
-   * @param sourcePath The path of the NBT to modify with.
-   */
   @command(['from', 'entity'])
-  fromEntity = (source: SingleEntityArgument, sourcePath: string) => { }
+  private fromEntity = (...args: unknown[]) => { }
 
-  /**
-   * Modify with the NBT of a given storage path.
-   *
-   * @param source The storage path to modify the NBT with.
-   * @param sourcePath The path of the NBT to modify with.
-   */
   @command(['from', 'storage'])
-  fromStorage = (source: string, sourcePath: string) => { }
+  private fromStorage = (...args: unknown[]) => { }
+
+  from: {
+    /**
+     * Modify with the NBT of a block at the given position.
+     *
+     * @param sourcePosition The coordinates of the block to modify the NBT with.
+     * @param sourcePath The path of the NBT to modify with.
+     */
+    block: (sourcePosition: Coordinates, sourcePath: string) => void
+
+    /**
+     * Modify with the NBT of a given entity.
+     *
+     * @param source The entity to modify the NBT with.
+     * @param sourcePath The path of the NBT to modify with.
+     */
+    entity: (source: SingleEntityArgument, sourcePath: string) => void
+
+    /**
+     * Modify with the NBT of a given storage path.
+     *
+     * @param source The storage path to modify the NBT with.
+     * @param sourcePath The path of the NBT to modify with.
+     */
+    storage: (source: string, sourcePath: string) => void
+  } = {
+    block: this.fromBlock,
+    entity: this.fromEntity,
+    storage: this.fromStorage,
+  }
 
   /**
    * Modify the NBT with the given value.

--- a/src/commands/implementations/Execute.ts
+++ b/src/commands/implementations/Execute.ts
@@ -48,8 +48,6 @@ function isRealCommandsRoot(commandsRootLike: CommandsRootLike): commandsRootLik
   return Object.prototype.hasOwnProperty.call(commandsRootLike, 'register')
 }
 
-type TEST<T> = 0
-
 export class ExecuteStoreArgs<T extends CommandsRootLike> extends ExecuteSubcommand<T> {
   /**
    * Saves the final command's return value as tag data within a block entity.
@@ -62,10 +60,10 @@ export class ExecuteStoreArgs<T extends CommandsRootLike> extends ExecuteSubcomm
    *
    * @param type Desired data size/type.
    *
-   * @param scale Multiplier to apply before storing value.
+   * @param scale Multiplier to apply before storing value. Defaults to 1.
    */
   @command('block', { ...executeConfig, parsers: { '0': coordinatesParser } })
-  block = (targetPos: Coordinates, path: string, type: StoreType, scale: number) => this.execute
+  block = (targetPos: Coordinates, path: string, type: StoreType, scale = 1) => this.execute
 
   /**
    * Saves the final command's return value in either a bossbar's current value or its maximum value.
@@ -90,11 +88,11 @@ export class ExecuteStoreArgs<T extends CommandsRootLike> extends ExecuteSubcomm
    *
    * @param type Desired data size/type.
    *
-   * @param scale Multiplier to apply before storing value.
+   * @param scale Multiplier to apply before storing value. Defaults to 1.
    */
   @command('entity', executeConfig)
   entity = (
-    target: SingleEntityArgument, path: string, type: StoreType, scale: number,
+    target: SingleEntityArgument, path: string, type: StoreType, scale = 1,
   ) => this.execute
 
   @command('score', executeConfig)
@@ -130,10 +128,10 @@ export class ExecuteStoreArgs<T extends CommandsRootLike> extends ExecuteSubcomm
    *
    * @param type Desired data size/type.
    *
-   * @param scale Multiplier to apply before storing value.
+   * @param scale Multiplier to apply before storing value. Defaults to 1.
    */
   @command('storage', executeConfig)
-  storage = (target: string, path: string, type: StoreType, scale: number) => this.execute
+  storage = (target: string, path: string, type: StoreType, scale = 1) => this.execute
 }
 
 export class ExecuteStore<T extends CommandsRootLike> extends ExecuteSubcommand<T> {

--- a/src/commands/implementations/Experience.ts
+++ b/src/commands/implementations/Experience.ts
@@ -24,7 +24,7 @@ export class Experience extends Command {
    *
    * If unspecified, defaults to `points`.
    */
-  @command(['experience', 'add'], { isRoot: true })
+  @command(['xp', 'add'], { isRoot: true })
   add = (targets: MultiplePlayersArgument, amount: number, type?: 'level' | 'points') => {
     validateIntegerRange(amount, 'amount', -2147483648, 2147483647)
   }
@@ -45,7 +45,7 @@ export class Experience extends Command {
    *
    * If unspecified, defaults to `points`.
    */
-  @command(['experience', 'set'], { isRoot: true })
+  @command(['xp', 'set'], { isRoot: true })
   set = (targets: MultiplePlayersArgument, amount: number, type?: 'level' | 'points') => {
     validateIntegerRange(amount, 'amount', 0, 2147483647)
   }
@@ -61,6 +61,6 @@ export class Experience extends Command {
    *
    * If unspecified, defaults to `points`.
    */
-  @command(['experience', 'query'], { isRoot: true })
+  @command(['xp', 'query'], { isRoot: true })
   query = (target: SinglePlayerArgument, type?: 'level' | 'points') => { }
 }

--- a/src/commands/implementations/Teleport.ts
+++ b/src/commands/implementations/Teleport.ts
@@ -29,7 +29,7 @@ export class TeleportFacing extends Command {
 }
 
 export class Teleport extends Command {
-  @command('teleport', {
+  @command('tp', {
     hasSubcommands: true,
     isRoot: true,
     executable: true,
@@ -39,7 +39,7 @@ export class Teleport extends Command {
       '2': rotationParser,
     },
   })
-  teleport: (
+  tp: (
     (
       /**
        * Teleports the executer to a given entity.

--- a/src/commandsOnly.ts
+++ b/src/commandsOnly.ts
@@ -51,7 +51,7 @@ export const {
   summon,
   tag,
   team,
-  teammessage,
+  teammsg,
   teleport,
   tellraw,
   time,
@@ -60,4 +60,8 @@ export const {
   w,
   weather,
   worldborder,
+  tm,
+  tp,
+  xp,
+  tell,
 } = commandsRoot

--- a/src/datapack/resourcesTree.ts
+++ b/src/datapack/resourcesTree.ts
@@ -233,7 +233,7 @@ export class ResourcesTree {
       const niceName = toMCFunctionName(resource.path)
 
       if (!previousResource || conflictStrategy === 'replace' || conflictStrategy === 'warn' || !previousResource.isResource) {
-        if (conflictStrategy === 'warn') {
+        if (conflictStrategy === 'warn' && previousResource && previousResource.isResource) {
           console.warn(
             chalk.keyword('orange')(
               'Warning:',

--- a/src/flow/Flow.ts
+++ b/src/flow/Flow.ts
@@ -1,7 +1,7 @@
 import { isAsyncFunction } from '@/utils'
 import { Execute } from '@commands/implementations/Execute'
 import { toMCFunctionName } from '@datapack/minecraft'
-import { coordinatesParser } from '@variables'
+import { ConditionClass, coordinatesParser } from '@variables'
 import { PlayerScore } from '@variables/PlayerScore'
 
 import { CombinedConditions, getConditionScore } from './conditions'
@@ -14,10 +14,15 @@ import type { CommandsRoot } from '@commands'
 import type { Datapack } from '@datapack'
 import type { CommandArgs } from '@datapack/minecraft'
 import type { FunctionResource } from '@datapack/resourcesTree'
-import type { ConditionClass } from '@variables'
 import type { ConditionType } from './conditions'
 
 const ASYNC_CALLBACK_NAME = '__await_flow'
+
+function valueToCondition(value: unknown[]): ConditionClass {
+  const condition = new ConditionClass()
+  condition._toMinecraftCondition = () => ({ value })
+  return condition
+}
 
 /** Call a given callback function, and inline it if possible */
 function callOrInlineFunction(datapack: Datapack, callbackFunction: FunctionResource, forceInlineScore?: PlayerScore) {
@@ -113,9 +118,9 @@ export class Flow {
    *
    * @param block A block to test against.
    */
-  block = (coords: Coordinates, block: LiteralUnion<BLOCKS>): ConditionClass => ({
-    _toMinecraftCondition: () => ({ value: ['if', 'block', coordinatesParser(coords), block] }),
-  })
+  block = (coords: Coordinates, block: LiteralUnion<BLOCKS>): ConditionClass => (
+    valueToCondition(['if', 'block', coordinatesParser(coords), block])
+  )
 
   /**
    * Compares the blocks in two equally sized volumes. Suceeds if both are identical.
@@ -130,9 +135,9 @@ export class Flow {
    *
    * @param scanMode Specifies whether all blocks in the source volume should be compared, or if air blocks should be masked/ignored.
    */
-  blocks = (start: Coordinates, end: Coordinates, destination: Coordinates, scanMode: 'all' | 'masked'): ConditionClass => ({
-    _toMinecraftCondition: () => ({ value: ['if', 'blocks', coordinatesParser(start), coordinatesParser(end), coordinatesParser(destination), scanMode] }),
-  })
+  blocks = (start: Coordinates, end: Coordinates, destination: Coordinates, scanMode: 'all' | 'masked'): ConditionClass => (
+    valueToCondition(['if', 'blocks', coordinatesParser(start), coordinatesParser(end), coordinatesParser(destination), scanMode])
+  )
 
   /**
    * Checks if the given target has any data for a given tag.
@@ -159,21 +164,21 @@ export class Flow {
      * @param pos Position of the block to be tested.
      * @param path Data tag to check for.
      */
-    block: (pos: Coordinates, path: string) => ({ value: ['if', 'data', 'block', coordinatesParser(pos), path] }),
+    block: (pos: Coordinates, path: string) => valueToCondition(['if', 'data', 'block', coordinatesParser(pos), path]),
 
     /**
      * Checks whether the targeted entity has any data for a given tag
      * @param target One single entity to be tested.
      * @param path Data tag to check for.
      */
-    entity: (target: SingleEntityArgument, path: string) => ({ value: ['if', 'data', 'entity', target, path] }),
+    entity: (target: SingleEntityArgument, path: string) => valueToCondition(['if', 'data', 'entity', target, path]),
 
     /**
      * Checks whether the targeted storage has any data for a given tag
      * @param source The storage to check in.
      * @param path Data tag to check for.
      */
-    storage: (source: string, path: string) => ({ value: ['if', 'data', 'storage', source, path] }),
+    storage: (source: string, path: string) => valueToCondition(['if', 'data', 'storage', source, path]),
   }
 
   /** Logical operators */

--- a/src/flow/conditions.ts
+++ b/src/flow/conditions.ts
@@ -1,7 +1,6 @@
 import type { CommandsRoot } from '@commands'
 import type { Datapack } from '@datapack'
 import type { ConditionClass } from '@variables'
-import type { PlayerScore } from '@variables/PlayerScore'
 
 export function conditionToString(condition: ConditionType): string {
   if (condition instanceof CombinedConditions) {


### PR DESCRIPTION
Changelog:
- `execute.ifScore/Block/Data...` are all replaced by `execute.if.score/block/data...`.
- `data.modify...fromEntity/Storage/Block` are all replaced by `data.modify...from.entity/storage/block`.
- Added all command aliases (`tp`, `w`, `tm`, `xp` and `tell`).
- Commands with aliases (`experience`, `teleport`...) will now compile to their smallest alias.
- Fixed `_.data` not being a correct argument for `_.if`.
- Fixed incorrect warnings about functions being overriden.