### PR TITLE
Fixed a bunch of bugs & renamed some types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandstone",
   "description": "Sandstone, a Typescript library for Minecraft datapacks.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": "TheMrZZ - Florian ERNST",
   "bugs": {
     "url": "https://github.com/TheMrZZ/sandstone/issues"

--- a/src/arguments/jsonTextComponent.ts
+++ b/src/arguments/jsonTextComponent.ts
@@ -94,7 +94,7 @@ type ChildrenTags = {
    * Child text components inherit all formatting and interactivity from the parent component,
    * unless they explicitly override them.
    */
-  extra?: JsonTextComponent[]
+  extra?: JSONTextComponent[]
 }
 
 type FormattingTags = {
@@ -190,7 +190,7 @@ type InteractivityTags = {
      * `show_item`: The item that should be displayed.
      * `show_entity`: The entity that should be displayed.
      */
-    contents: JsonTextComponent
+    contents: JSONTextComponent
   } | {
     action: 'show_item'
 
@@ -230,13 +230,13 @@ export type TextComponentObject = (
 )
 
 /*
- * A Json text component, that can be displayed in several locations: in-game chat, books, signs, titles...
+ * A JSON text component, that can be displayed in several locations: in-game chat, books, signs, titles...
  */
-export type JsonTextComponent = (
+export type JSONTextComponent = (
   string |
   boolean |
   number |
   TextComponentObject |
   ComponentClass |
-  JsonTextComponent[]
+  JSONTextComponent[]
 )

--- a/src/arguments/jsonTextComponent.ts
+++ b/src/arguments/jsonTextComponent.ts
@@ -94,7 +94,7 @@ type ChildrenTags = {
    * Child text components inherit all formatting and interactivity from the parent component,
    * unless they explicitly override them.
    */
-  extra?: TextComponentObject[]
+  extra?: JsonTextComponent[]
 }
 
 type FormattingTags = {
@@ -229,22 +229,14 @@ export type TextComponentObject = (
   ContentTag & ChildrenTags & FormattingTags & InteractivityTags
 )
 
-/**
- * All possible chat components
+/*
+ * A Json text component, that can be displayed in several locations: in-game chat, books, signs, titles...
  */
-type PossibleComponent = (
+export type JsonTextComponent = (
   string |
   boolean |
   number |
   TextComponentObject |
   ComponentClass |
-  PossibleComponent[]
-)
-
-/*
- * A Json text component, that can be displayed in several locations: in-game chat, books, signs, titles...
- */
-export type JsonTextComponent = (
-  readonly PossibleComponent[] |
-  PossibleComponent
+  JsonTextComponent[]
 )

--- a/src/arguments/resources/advancement.ts
+++ b/src/arguments/resources/advancement.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import type { ITEMS, JsonTextComponent, RootNBT } from 'src/arguments'
+import type { ITEMS, JSONTextComponent, RootNBT } from 'src/arguments'
 import type { LiteralUnion } from '@/generalTypes'
 import type { MCFunctionInstance } from '@datapack/Datapack'
 import type { AdvancementInstance } from '@resources'
@@ -19,7 +19,7 @@ export interface AdvancementJSON<CRITERIA_NAMES extends string = string> {
     }
 
     /** The title for this advancement. */
-    title: JsonTextComponent
+    title: JSONTextComponent
 
     /**
      * The optional type of frame for the icon.
@@ -30,7 +30,7 @@ export interface AdvancementJSON<CRITERIA_NAMES extends string = string> {
     frame?: 'challenge' | 'goal' | 'task'
 
     /** The description of the advancement. */
-    description: JsonTextComponent
+    description: JSONTextComponent
 
     /** Whether or not to show the toast pop up after completing this advancement. Defaults to `true`. */
     show_toast?: boolean

--- a/src/arguments/resources/lootTables.ts
+++ b/src/arguments/resources/lootTables.ts
@@ -3,7 +3,7 @@ import type { MAP_ICONS } from 'src/arguments/basics'
 import type {
   BLOCKS, ENCHANTMENTS, ITEMS, STRUCTURES,
 } from 'src/arguments/generated'
-import type { JsonTextComponent } from 'src/arguments/jsonTextComponent'
+import type { JSONTextComponent } from 'src/arguments/jsonTextComponent'
 import type { LiteralUnion } from '@/generalTypes'
 import type { NumberOrMinMax } from './criteria'
 import type { ObjectOrArray, PredicateCondition } from './predicate'
@@ -230,7 +230,7 @@ type LootTableFunction = {
   }>
   | FunctionType<'set_lore', {
     /** List of JSON text components. Each list entry represents one line of the lore. */
-    lore: JsonTextComponent[]
+    lore: JSONTextComponent[]
     /**
      * Specifies the entity to act as the source @s in the JSON text component. Set to:
      * - `this` to use the entity that died or the player that gained the advancement, opened the container or broke the block
@@ -243,7 +243,7 @@ type LootTableFunction = {
   }>
   | FunctionType<'set_name', {
     /** A JSON text component name, allowing color, translations, etc. */
-    name: JsonTextComponent
+    name: JSONTextComponent
     /**
      * Specifies the entity to act as the source @s in the JSON text component. Set to:
      * - `this` to use the entity that died or the player that gained the advancement, opened the container or broke the block

--- a/src/commands/CommandsRoot.ts
+++ b/src/commands/CommandsRoot.ts
@@ -1,5 +1,5 @@
 import { nbtParser } from '@variables'
-import { JsonTextComponentClass } from '@variables/JsonTextComponentClass'
+import { JSONTextComponentClass } from '@variables/JSONTextComponentClass'
 
 import { coordinatesParser, rotationParser } from '../variables/parsers'
 import { command } from './decorators'
@@ -21,7 +21,7 @@ import type {
   GAMEMODES,
   GAMERULES,
   ITEMS,
-  JsonTextComponent,
+  JSONTextComponent,
   MessageOrSelector,
   MultipleEntitiesArgument,
   MultiplePlayersArgument,
@@ -503,8 +503,8 @@ export class CommandsRoot {
   w = (targets: MultiplePlayersArgument, ...messages: AtLeastOne<MessageOrSelector>) => { }
 
   // tellraw command //
-  @command('tellraw', { isRoot: true, parsers: { '1': (msg) => new JsonTextComponentClass(msg) } })
-  tellraw = (targets: MultiplePlayersArgument, message: JsonTextComponent) => { }
+  @command('tellraw', { isRoot: true, parsers: { '1': (msg) => new JSONTextComponentClass(msg) } })
+  tellraw = (targets: MultiplePlayersArgument, message: JSONTextComponent) => { }
 
   // time command //
   time = new Time(this)

--- a/src/commands/decorators.ts
+++ b/src/commands/decorators.ts
@@ -94,10 +94,10 @@ type RegisterConfig = {
    * Please note that the unparsed argument will be given to the function itself, to avoid types problems.
    *
    * @example
-   * `@command`('tellraw', { parsers: { 1: JsonTextComponentClass } })
-   * tellraw = (targets: string, textComponent: JsonTextComponent) => {}
+   * `@command`('tellraw', { parsers: { 1: JSONTextComponentClass } })
+   * tellraw = (targets: string, textComponent: JSONTextComponent) => {}
    *
-   * => The `textComponent` argument will be casted to a JsonTextComponentClass when registered.
+   * => The `textComponent` argument will be casted to a JSONTextComponentClass when registered.
    */
   parsers?: Record<number | string, (arg: any, innerArgs: unknown[]) => unknown>
 

--- a/src/commands/implementations/Bossbar.ts
+++ b/src/commands/implementations/Bossbar.ts
@@ -1,10 +1,10 @@
 import { MultipleEntitiesArgument } from 'src/arguments'
-import { JsonTextComponentClass } from '@variables'
+import { JSONTextComponentClass } from '@variables'
 
 import { Command } from '../Command'
 import { command } from '../decorators'
 
-import type { BASIC_COLORS, JsonTextComponent, MultiplePlayersArgument } from 'src/arguments'
+import type { BASIC_COLORS, JSONTextComponent, MultiplePlayersArgument } from 'src/arguments'
 import type { LiteralUnion } from '@/generalTypes'
 
 export class Bossbar extends Command {
@@ -15,8 +15,8 @@ export class Bossbar extends Command {
    *
    * @param name The display name of the boss bar.
    */
-  @command(['bossbar', 'add'], { isRoot: true, parsers: { '1': (arg) => new JsonTextComponentClass(arg) } })
-  add = (id: string, name: JsonTextComponent) => { }
+  @command(['bossbar', 'add'], { isRoot: true, parsers: { '1': (arg) => new JSONTextComponentClass(arg) } })
+  add = (id: string, name: JSONTextComponent) => { }
 
   /**
    * Return the requested setting as a result of the command.

--- a/src/commands/implementations/Execute.ts
+++ b/src/commands/implementations/Execute.ts
@@ -402,7 +402,7 @@ export class Execute<T extends CommandsRootLike> extends CommandLike<T> {
   @command(['unless', 'blocks'], executeConfig)
   private unlessBlocks: IfsAndUnlesses<T, this>['ifBlocks'] = (...args: unknown[]) => this
 
-  private get ifData(): IfsAndUnlesses<T, this>['ifData'] {
+  private ifData = (): IfsAndUnlesses<T, this>['ifData'] => {
     if (!this.commandsRoot.arguments.length) {
       this.commandsRoot.arguments.push('execute')
     }
@@ -416,7 +416,7 @@ export class Execute<T extends CommandsRootLike> extends CommandLike<T> {
     return new ExecuteIfData(this as unknown as InferExecute<T>)
   }
 
-  private get unlessData(): IfsAndUnlesses<T, this>['ifData'] {
+  private unlessData = (): IfsAndUnlesses<T, this>['ifData'] => {
     if (!this.commandsRoot.arguments.length) {
       this.commandsRoot.arguments.push('execute')
     }
@@ -475,16 +475,21 @@ export class Execute<T extends CommandsRootLike> extends CommandLike<T> {
 
   /** Checks if the given condition is met. */
   get if(): ((condition: ConditionClass) => this) & IfType<T, this> {
-    return Object.assign(
+    const result = Object.assign(
       (condition: ConditionClass) => this.if_(...condition._toMinecraftCondition().value), {
         block: this.ifBlock,
         blocks: this.ifBlocks,
-        data: this.ifData,
+        data: 0 as any, // We are going to override it just below
         entity: this.ifEntity,
         predicate: this.ifPredicate,
         score: this.ifScore,
       },
     )
+
+    Object.defineProperty(result, 'data', {
+      get: this.ifData,
+    })
+    return result
   }
 
   /** Checks if the given conditions is not met. */
@@ -500,14 +505,20 @@ export class Execute<T extends CommandsRootLike> extends CommandLike<T> {
       return this.if_(...args)
     }
 
-    return Object.assign(func, {
+    const result = Object.assign(func, {
       block: this.unlessBlock,
       blocks: this.unlessBlocks,
-      data: this.unlessData,
+      data: 0 as any, // We are going to override it just below
       entity: this.unlessEntity,
       predicate: this.unlessPredicate,
       score: this.unlessScore,
     })
+
+    Object.defineProperty(result, 'data', {
+      get: this.unlessData,
+    })
+
+    return result
   }
 
   @command([], {

--- a/src/commands/implementations/Scoreboard.ts
+++ b/src/commands/implementations/Scoreboard.ts
@@ -1,10 +1,10 @@
-import { JsonTextComponentClass } from '@variables'
+import { JSONTextComponentClass } from '@variables'
 
 import { Command } from '../Command'
 import { command } from '../decorators'
 
 import type {
-  JsonTextComponent, MultipleEntitiesArgument, OBJECTIVE_CRITERION,
+  JSONTextComponent, MultipleEntitiesArgument, OBJECTIVE_CRITERION,
   ObjectiveArgument, OPERATORS,
 } from 'src/arguments'
 import type { DISPLAY_SLOTS } from 'src/arguments/displaySlots'
@@ -43,10 +43,10 @@ class ScoreboardObjectives extends Command {
   @command(objectiveCmd('add'), {
     isRoot: true,
     parsers: {
-      '2': (displayName) => (displayName ? new JsonTextComponentClass(displayName) : displayName),
+      '2': (displayName) => (displayName ? new JSONTextComponentClass(displayName) : displayName),
     },
   })
-  add = (objective: string, criteria: LiteralUnion<OBJECTIVE_CRITERION>, displayName?: JsonTextComponent) => {
+  add = (objective: string, criteria: LiteralUnion<OBJECTIVE_CRITERION>, displayName?: JSONTextComponent) => {
     if (objective.length > 16) {
       throw new Error(`Objectives cannot have names with more than 16 characters. Got ${objective.length} with objective "${objective}".`)
     }
@@ -89,7 +89,7 @@ class ScoreboardObjectives extends Command {
   @command(objectiveCmd('modify'), {
     isRoot: true,
     parsers: {
-      '2': (displayName, [_, type]) => (type === 'displayname' ? new JsonTextComponentClass(displayName) : displayName),
+      '2': (displayName, [_, type]) => (type === 'displayname' ? new JSONTextComponentClass(displayName) : displayName),
     },
   })
   modify: (
@@ -108,7 +108,7 @@ class ScoreboardObjectives extends Command {
    *
    * @param displayName The new display name. Must be a JSON text component.
    */
-  ((objective: ObjectiveArgument, type: 'displayname', displayName?: JsonTextComponent) => void) &
+  ((objective: ObjectiveArgument, type: 'displayname', displayName?: JSONTextComponent) => void) &
 
   /**
    * Change the display format of health bars.

--- a/src/commands/implementations/Team.ts
+++ b/src/commands/implementations/Team.ts
@@ -1,22 +1,22 @@
 import { SelectorArgument } from 'src/arguments'
 import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
-import { JsonTextComponentClass } from '@variables'
+import { JSONTextComponentClass } from '@variables'
 
-import type { BASIC_COLORS, JsonTextComponent, MultipleEntitiesArgument } from 'src/arguments'
+import type { BASIC_COLORS, JSONTextComponent, MultipleEntitiesArgument } from 'src/arguments'
 
 interface TeamOptions {
   collisionRule: 'always' | 'never' | 'pushOtherTeams' | 'pushOwnTeam'
   color: BASIC_COLORS
   deathMessageVisibility: 'never' | 'hideForOtherTeams' | 'hideForOwnTeam' | 'always'
-  displayName: JsonTextComponent
+  displayName: JSONTextComponent
   friendlyFire: boolean
   nametagVisibility: 'never' | 'hideForOtherTeams' | 'hideForOwnTeam' | 'always'
-  prefix: JsonTextComponent
+  prefix: JSONTextComponent
   seeFriendlyInvisibles: boolean
 
   /** Hey */
-  suffix: JsonTextComponent
+  suffix: JSONTextComponent
 }
 
 export class Team extends Command {
@@ -30,10 +30,10 @@ export class Team extends Command {
   @command(['team', 'add'], {
     isRoot: true,
     parsers: {
-      '1': (displayName) => new JsonTextComponentClass(displayName),
+      '1': (displayName) => new JSONTextComponentClass(displayName),
     },
   })
-  add = (team: string, displayName?: JsonTextComponent) => {}
+  add = (team: string, displayName?: JSONTextComponent) => {}
 
   /**
    * Removes all members from a team.

--- a/src/commands/implementations/Title.ts
+++ b/src/commands/implementations/Title.ts
@@ -1,9 +1,9 @@
 import { MultipleEntitiesArgument, SelectorArgument } from 'src/arguments'
 import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
-import { JsonTextComponentClass, SelectorClass } from '@variables'
+import { JSONTextComponentClass, SelectorClass } from '@variables'
 
-import type { JsonTextComponent, MultiplePlayersArgument } from 'src/arguments'
+import type { JSONTextComponent, MultiplePlayersArgument } from 'src/arguments'
 
 export class TitleArguments extends Command {
   @command('clear')
@@ -14,24 +14,24 @@ export class TitleArguments extends Command {
 
   @command('title', {
     parsers: {
-      '0': (title) => new JsonTextComponentClass(title),
+      '0': (title) => new JSONTextComponentClass(title),
     },
   })
-  title = (title: JsonTextComponent) => {}
+  title = (title: JSONTextComponent) => {}
 
   @command('subtitle', {
     parsers: {
-      '0': (subtitle) => new JsonTextComponentClass(subtitle),
+      '0': (subtitle) => new JSONTextComponentClass(subtitle),
     },
   })
-  subtitle = (subtitle: JsonTextComponent) => {}
+  subtitle = (subtitle: JSONTextComponent) => {}
 
   @command('actionbar', {
     parsers: {
-      '0': (actionbar) => new JsonTextComponentClass(actionbar),
+      '0': (actionbar) => new JSONTextComponentClass(actionbar),
     },
   })
-  actionbar = (actionbarText: JsonTextComponent) => {}
+  actionbar = (actionbarText: JSONTextComponent) => {}
 
   @command('times')
   times = (fadeIn: number, stay: number, fadeOut: number) => {}

--- a/src/datapack/Datapack.ts
+++ b/src/datapack/Datapack.ts
@@ -8,7 +8,7 @@ import { toMCFunctionName } from './minecraft'
 import { ResourcesTree } from './resourcesTree'
 import { saveDatapack } from './saveDatapack'
 
-import type { JsonTextComponent, OBJECTIVE_CRITERION, TimeArgument } from 'src/arguments'
+import type { JSONTextComponent, OBJECTIVE_CRITERION, TimeArgument } from 'src/arguments'
 import type { BASIC_CONFLICT_STRATEGIES, HideFunctionProperties, LiteralUnion } from '@/generalTypes'
 import type {
   AdvancementOptions, LootTableOptions, MCFunctionClass, MCFunctionOptions, PredicateOptions, RecipeOptions, TagOptions,
@@ -45,7 +45,7 @@ export interface SandstoneConfig {
    * Can be a single string or a JSON Text Component
    * (like in /tellraw or /title).
    */
-  description: JsonTextComponent
+  description: JSONTextComponent
 
   /**
    * The format version of the data pack.
@@ -450,7 +450,7 @@ export default class Datapack {
 
   /** UTILS */
   /** Create a new objective. Defaults to `dummy` if unspecified. */
-  createObjective = (name: string, criteria: LiteralUnion<OBJECTIVE_CRITERION> = 'dummy', display?: JsonTextComponent) => {
+  createObjective = (name: string, criteria: LiteralUnion<OBJECTIVE_CRITERION> = 'dummy', display?: JSONTextComponent) => {
     if (name.length > 16) {
       throw new Error(`Objectives cannot have names with more than 16 characters. Got ${name.length} with objective "${name}".`)
     }
@@ -461,7 +461,7 @@ export default class Datapack {
   }
 
   /** Get an objective, and create it if it does not exists. */
-  getCreateObjective(name: string, criteria: string, display?: JsonTextComponent) {
+  getCreateObjective(name: string, criteria: string, display?: JSONTextComponent) {
     try {
       return this.createObjective(name, criteria, display)
     } catch (e) {

--- a/src/datapack/saveDatapack.ts
+++ b/src/datapack/saveDatapack.ts
@@ -8,7 +8,7 @@ import {
 } from './filesystem'
 import packMcMeta from './packMcMeta.json'
 
-import type { JsonTextComponent } from 'src/arguments'
+import type { JSONTextComponent } from 'src/arguments'
 import type {
   ResourceOnlyTypeMap,
   ResourcesTree,
@@ -58,7 +58,7 @@ export type SaveOptions = {
    *
    * Can be a string or a JSON Text Component.
    */
-  description?: JsonTextComponent
+  description?: JSONTextComponent
 
   /**
    * The format version of the datapack.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {
   relative as rel,
 } from '.'
 export * from './variables/Coordinates'
-export * from './variables/JsonTextComponentClass'
+export * from './variables/JSONTextComponentClass'
 export * from './variables/NBTs'
 export * from './variables/Objective'
 export * from './variables/parsers'

--- a/src/resources/Advancement.ts
+++ b/src/resources/Advancement.ts
@@ -18,12 +18,12 @@ export type AdvancementOptions = {
 }
 
 export class AdvancementInstance<CriteriaNames extends string = string> extends ResourceInstance {
-  advancementJson
+  advancementJSON
 
   constructor(datapack: Datapack, name: string, advancement: AdvancementJSON<CriteriaNames>, options?: AdvancementOptions) {
     super(datapack, name)
 
-    this.advancementJson = advancement
+    this.advancementJSON = advancement
 
     this.datapack.addResource(name, 'advancements', { advancement }, options?.onConflict ?? CONFLICT_STRATEGIES.ADVANCEMENT)
   }

--- a/src/resources/LootTable.ts
+++ b/src/resources/LootTable.ts
@@ -20,12 +20,12 @@ export type LootTableOptions = {
 }
 
 export class LootTableInstance extends ResourceInstance {
-  lootTableJson
+  lootTableJSON
 
   constructor(datapack: Datapack, name: string, lootTable: LootTableJSON, options?: LootTableOptions) {
     super(datapack, name)
 
-    this.lootTableJson = lootTable
+    this.lootTableJSON = lootTable
 
     datapack.addResource(name, 'loot_tables', { lootTable }, options?.onConflict ?? CONFLICT_STRATEGIES.LOOT_TABLE)
   }

--- a/src/resources/Predicate.ts
+++ b/src/resources/Predicate.ts
@@ -19,12 +19,12 @@ export type PredicateOptions = {
 }
 
 export class PredicateInstance extends ResourceInstance implements ConditionClass {
-  predicateJson
+  predicateJSON
 
   constructor(datapack: Datapack, name: string, predicate: PredicateJSON, options?: PredicateOptions) {
     super(datapack, name)
 
-    this.predicateJson = predicate
+    this.predicateJSON = predicate
 
     this.commandsRoot.Datapack.addResource(name, 'predicates', { predicate }, options?.onConflict ?? CONFLICT_STRATEGIES.PREDICATE)
   }

--- a/src/resources/Recipe.ts
+++ b/src/resources/Recipe.ts
@@ -18,12 +18,12 @@ export type RecipeOptions = {
 }
 
 export class RecipeInstance<P1 extends string = string, P2 extends string = string, P3 extends string = string> extends ResourceInstance {
-  recipeJson
+  recipeJSON
 
   constructor(datapack: Datapack, name: string, recipe: RecipeJSON<P1, P2, P3>, options?: RecipeOptions) {
     super(datapack, name)
 
-    this.recipeJson = recipe
+    this.recipeJSON = recipe
 
     this.datapack.addResource(name, 'recipes', { recipe }, options?.onConflict ?? CONFLICT_STRATEGIES.RECIPE)
   }

--- a/src/variables/JsonTextComponentClass.ts
+++ b/src/variables/JsonTextComponentClass.ts
@@ -1,9 +1,9 @@
-import type { JsonTextComponent } from 'src/arguments'
+import type { JSONTextComponent } from 'src/arguments'
 
-export class JsonTextComponentClass {
-  jsonTextComponent: JsonTextComponent
+export class JSONTextComponentClass {
+  jsonTextComponent: JSONTextComponent
 
-  constructor(jsonTextComponent: JsonTextComponent) {
+  constructor(jsonTextComponent: JSONTextComponent) {
     this.jsonTextComponent = jsonTextComponent
   }
 

--- a/src/variables/Objective.ts
+++ b/src/variables/Objective.ts
@@ -1,7 +1,7 @@
-import { JsonTextComponentClass } from './JsonTextComponentClass'
+import { JSONTextComponentClass } from './JSONTextComponentClass'
 import { PlayerScore } from './PlayerScore'
 
-import type { JsonTextComponent, MultipleEntitiesArgument, OBJECTIVE_CRITERION } from 'src/arguments'
+import type { JSONTextComponent, MultipleEntitiesArgument, OBJECTIVE_CRITERION } from 'src/arguments'
 import type { LiteralUnion } from '@/generalTypes'
 import type { CommandsRoot } from '@commands'
 
@@ -12,15 +12,15 @@ export class ObjectiveClass {
 
   criterion: string
 
-  display: JsonTextComponentClass | undefined
+  display: JSONTextComponentClass | undefined
 
-  _displayRaw: JsonTextComponent | undefined
+  _displayRaw: JSONTextComponent | undefined
 
-  constructor(commandsRoot: CommandsRoot, name: string, criterion: LiteralUnion<OBJECTIVE_CRITERION>, display?: JsonTextComponent) {
+  constructor(commandsRoot: CommandsRoot, name: string, criterion: LiteralUnion<OBJECTIVE_CRITERION>, display?: JSONTextComponent) {
     this.commandsRoot = commandsRoot
     this.name = name
     this.criterion = criterion as string
-    this.display = display === undefined ? undefined : new JsonTextComponentClass(display)
+    this.display = display === undefined ? undefined : new JSONTextComponentClass(display)
     this._displayRaw = display
   }
 
@@ -37,7 +37,7 @@ export function Objective(
   commandsRoot: CommandsRoot,
   name: string,
   criterion: string,
-  display?: JsonTextComponent,
+  display?: JSONTextComponent,
 ): ObjectiveClass {
   return new ObjectiveClass(
     commandsRoot,

--- a/src/variables/PlayerScore.ts
+++ b/src/variables/PlayerScore.ts
@@ -2,7 +2,7 @@ import { ComponentClass } from '@variables/abstractClasses'
 import { rangeParser } from '@variables/parsers'
 
 import type {
-  COMPARISON_OPERATORS, JsonTextComponent, MultipleEntitiesArgument, ObjectiveArgument, OPERATORS,
+  COMPARISON_OPERATORS, JSONTextComponent, MultipleEntitiesArgument, ObjectiveArgument, OPERATORS,
 } from 'src/arguments'
 import type { CommandsRoot } from '@commands'
 import type { Datapack } from '@datapack'
@@ -52,7 +52,7 @@ export class PlayerScore extends ComponentClass implements ConditionClass {
     return `${this.target} ${this.objective}`
   }
 
-  protected _toChatComponent(): JsonTextComponent {
+  protected _toChatComponent(): JSONTextComponent {
     return {
       score: { name: this.target, objective: this.objective.name },
     }

--- a/src/variables/Selector.ts
+++ b/src/variables/Selector.ts
@@ -5,7 +5,7 @@ import { nbtParser, rangeParser } from '@variables/parsers'
 import { ComponentClass } from './abstractClasses'
 
 import type {
-  ENTITY_TYPES, RootNBT, TextComponentObject,
+  ENTITY_TYPES, GAMEMODES, RootNBT, TextComponentObject,
 } from 'src/arguments'
 import type { CommandsRoot } from '@commands'
 import type { PredicateInstance } from '@resources'
@@ -79,7 +79,7 @@ export type SelectorProperties<MustBeSingle extends boolean, MustBePlayer extend
   level?: Range
 
   /** Filter target selection to those who are in the specified game mode. */
-  gamemode?: LiteralUnion<'adventure' | 'creative' | 'spectator' | 'survival' | '!adventure' | '!creative' | '!spectator' | '!survival'>
+  gamemode?: LiteralUnion<GAMEMODES | `!${GAMEMODES}`> | `!${GAMEMODES}`[]
 
   // Selecting targets by vertical rotation
 
@@ -252,6 +252,12 @@ export class SelectorClass<IsSingle extends boolean = false, IsPlayer extends bo
         tag: (tag: string | string[]) => {
           const tags = Array.isArray(tag) ? tag : [tag]
           result.push(...tags.map((tag_) => ['tag', tag_] as const))
+        },
+
+        // Parse potentially multiple gamemodes
+        gamemode: (gamemode: string | string[]) => {
+          const gamemodes = Array.isArray(gamemode) ? gamemode : [gamemode]
+          result.push(...gamemodes.map((gamemode_) => ['gamemode', gamemode_] as const))
         },
 
         // Parse potentially multiple predicates

--- a/src/variables/abstractClasses.ts
+++ b/src/variables/abstractClasses.ts
@@ -1,7 +1,7 @@
-import type { JsonTextComponent } from 'src/arguments/jsonTextComponent'
+import type { JSONTextComponent } from 'src/arguments/jsonTextComponent'
 
 export class ComponentClass {
-  protected _toChatComponent(): JsonTextComponent {
+  protected _toChatComponent(): JSONTextComponent {
     throw new Error('Not implemented')
   }
 }
@@ -16,7 +16,7 @@ export class ConditionClass {
 }
 
 export class ConditionTextComponentClass {
-  protected _toChatComponent(): JsonTextComponent {
+  protected _toChatComponent(): JSONTextComponent {
     throw new Error('Not implemented')
   }
 

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -1,6 +1,6 @@
 export * from './abstractClasses'
 export * from './Coordinates'
-export * from './JsonTextComponentClass'
+export * from './JSONTextComponentClass'
 export * from './Objective'
 export * from './parsers'
 export * from './Selector'


### PR DESCRIPTION
Changelog:
- Fixed `execute.if.<something>` adding a 'if data' in the output.
- Renamed all internal types & classes mentionning `Json` to `JSON`.
- Removed `readonly` property on `JsonTextComponent`, and changed `extra` to be an array of `JsonTextComponents`.
- Selectors now support multiple negative gamemodes: `gamemode: ['!creative', '!survival']`