### PR TITLE
Update TSDoc to match changes to Objective abstraction

### DIFF
--- a/src/commands/implementations/Scoreboard.ts
+++ b/src/commands/implementations/Scoreboard.ts
@@ -30,7 +30,7 @@ class ScoreboardObjectives extends Command {
    * --------------------------------------------------
    * ⚠️ The prefered way is using:
    * ```
-   * const objective = createObjective(...)
+   * const objective = Objective.create(...)
    * ```
    * --------------------------------------------------
    *
@@ -60,7 +60,7 @@ class ScoreboardObjectives extends Command {
    * --------------------------------------------------
    * ⚠️ The prefered way is using:
    * ```
-   * const objective = createObjective(...)
+   * const objective = Objective.create(...)
    * objective.remove()
    * ```
    * --------------------------------------------------
@@ -74,7 +74,7 @@ class ScoreboardObjectives extends Command {
    * --------------------------------------------------
    * ⚠️ The prefered way is using:
    * ```
-   * const objective = createObjective(...)
+   * const objective = Objective.create(...)
    * objective.setDisplay(...)
    * ```
    * --------------------------------------------------
@@ -99,7 +99,7 @@ class ScoreboardObjectives extends Command {
    * --------------------------------------------------
    * ⚠️ The prefered way is using:
    * ```
-   * const objective = createObjective(...)
+   * const objective = Objective.create(...)
    * objective.modify(...)
    * ```
    * --------------------------------------------------
@@ -116,7 +116,7 @@ class ScoreboardObjectives extends Command {
    * --------------------------------------------------
    * ⚠️ The prefered way is using:
    * ```
-   * const objective = createObjective(...)
+   * const objective = Objective.create(...)
    * objective.modify(...)
    * ```
    * --------------------------------------------------
@@ -159,7 +159,7 @@ class ScoreboardPlayers extends Command {
    * --------------------------------------------------
    * ⚠️ The prefered way is using:
    * ```
-   * const objective = createObjective(...)
+   * const objective = Objective.create(...)
    * const player = objective.ScoreHolder(...)
    * player.get()
    * ```


### PR DESCRIPTION
`createObjective` was separated into `Objective.create` and `Objective.get`; I changed the TSDoc to reflect this. The website docs should probably be changed too. I am definitely not salty about the fact that I spent 10 minutes trying to figure out why I couldn't import `createObjective`.