### PR TITLE
namespaces do not support dots in their names, despite the fact that minecraft can

### DIFF
--- a/src/datapack/BasePath.ts
+++ b/src/datapack/BasePath.ts
@@ -95,9 +95,9 @@ export class BasePathClass<N extends (undefined | string) = (undefined | string)
      * _ (Underscore)
      * - (Hyphen/minus)
      */
-    if (!namespace.match(/^[0-9a-z_-]+$/)) {
+    if (!namespace.match(/^[0-9a-z_-.]+$/)) {
       throw new Error(
-        `A namespace should only contain numbers, lowercase letters, underscores and hyphen/minus, and be at least 1 caracter long: got "${namespace}"`,
+        `A namespace should only contain numbers, lowercase letters, underscores, hyphen/minus and dot/period, and be at least 1 caracter long: got "${namespace}"`,
       )
     }
 

--- a/src/datapack/BasePath.ts
+++ b/src/datapack/BasePath.ts
@@ -95,7 +95,7 @@ export class BasePathClass<N extends (undefined | string) = (undefined | string)
      * _ (Underscore)
      * - (Hyphen/minus)
      */
-    if (!namespace.match(/^[0-9a-z_-.]+$/)) {
+    if (!namespace.match(/^[0-9a-z_\-.]+$/)) {
       throw new Error(
         `A namespace should only contain numbers, lowercase letters, underscores, hyphen/minus and dot/period, and be at least 1 caracter long: got "${namespace}"`,
       )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67161944/121734338-8eb12a00-caec-11eb-953d-05b81e537feb.png)
vs
![image](https://user-images.githubusercontent.com/67161944/121734356-94a70b00-caec-11eb-95f9-7abe85d70fb8.png)