### PR TITLE
Added type definitions to fix implicit types

### DIFF
--- a/src/datapack/resourcesTree.ts
+++ b/src/datapack/resourcesTree.ts
@@ -291,7 +291,7 @@ export class ResourcesTree {
 
       // Create the resource on the parent
       const newResource = handleConflict()
-      parent.children.set(newResource.path[resource.path.length - 1], newResource as any)
+      parent!.children.set(newResource.path[resource.path.length - 1], newResource as any)
     } else {
       // Our parent path only has one component, the namespace. We need to add the resource like this.
       const newResource = handleConflict()

--- a/src/resources/Tag.ts
+++ b/src/resources/Tag.ts
@@ -44,7 +44,7 @@ export type TagOptions = {
 }
 
 export class TagInstance<TYPE extends TAG_TYPES> extends ResourceInstance {
-  readonly type
+  readonly type: TYPE
 
   readonly values: TagSingleValue<string>[]
 

--- a/src/variables/Data.ts
+++ b/src/variables/Data.ts
@@ -39,7 +39,7 @@ function pathToString(path: DATA_PATH[]) {
 export class TargetlessDataInstance<TYPE extends DATA_TYPES = DATA_TYPES> {
   protected datapack
 
-  type
+  type: TYPE
 
   constructor(datapack: Datapack, type: TYPE) {
     this.datapack = datapack
@@ -54,7 +54,7 @@ export class TargetlessDataInstance<TYPE extends DATA_TYPES = DATA_TYPES> {
 export class TargetlessDataPointInstance<TYPE extends DATA_TYPES = DATA_TYPES> {
   protected datapack
 
-  type
+  type: TYPE
 
   path
 
@@ -72,9 +72,9 @@ export class TargetlessDataPointInstance<TYPE extends DATA_TYPES = DATA_TYPES> {
 export class DataInstance<TYPE extends DATA_TYPES = DATA_TYPES> {
   datapack
 
-  type
+  type: TYPE
 
-  currentTarget
+  currentTarget: DATA_TARGET[TYPE]
 
   constructor(datapack: Datapack, type: TYPE, target: DATA_TARGET[TYPE]) {
     this.datapack = datapack
@@ -97,11 +97,11 @@ export class DataInstance<TYPE extends DATA_TYPES = DATA_TYPES> {
 export class DataPointInstance<TYPE extends DATA_TYPES = DATA_TYPES> extends ConditionTextComponentClass {
   datapack
 
-  type
+  type: TYPE
 
   path
 
-  currentTarget
+  currentTarget: DATA_TARGET[TYPE]
 
   constructor(datapack: Datapack, type: TYPE, target: DATA_TARGET[TYPE], path: DATA_PATH[]) {
     super()
@@ -141,7 +141,7 @@ export class DataPointInstance<TYPE extends DATA_TYPES = DATA_TYPES> extends Con
      * Set the data point to the given score, with a given type and a scale.
      */
     ((value: Score, storeType: StoreType, scale?: number) => void)
-  ) = (value: NBTObject | DataPointInstance | Score, storeType?: StoreType, scale = 1) => {
+  ) = (value: NBTObject | DataPointInstance | Score, storeType?: StoreType, scale: number = 1) => {
     if (value instanceof Score) {
       this.executeStore(storeType as StoreType, scale).run.scoreboard.players.get(value.target, value.objective)
       return


### PR DESCRIPTION
In some places, when compiling with `tsc`, an implicit any type error is thrown, the editor also complains about those errors:
![image](https://user-images.githubusercontent.com/63411784/122153202-b4438800-ce8c-11eb-9fb8-9dffc04fc330.png)
This pull request fixes that by adding proper type definitions