### PR TITLE
Fix default imports in modules without default import

### DIFF
--- a/src/datapack/filesystem.ts
+++ b/src/datapack/filesystem.ts
@@ -1,5 +1,5 @@
-import os from 'os'
-import path from 'path'
+import * as os from 'os'
+import * as path from 'path'
 
 /**
  * Get the .minecraft path

--- a/src/datapack/saveDatapack.ts
+++ b/src/datapack/saveDatapack.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import path from 'path'
+import * as path from 'path'
 
 import {
   createDirectory, deleteDirectory, getMinecraftPath, getWorldPath,

--- a/src/resources/MCFunctionClass.ts
+++ b/src/resources/MCFunctionClass.ts
@@ -1,4 +1,4 @@
-import util from 'util'
+import * as util from 'util'
 import { CONFLICT_STRATEGIES } from '@/env'
 import { isPromise } from '@/utils'
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import util from 'util'
+import * as util from 'util'
 
 export function isAsyncFunction(func: ((...args: any[]) => void) | ((...args: any[]) => Promise<void>)): func is (...args: any[]) => Promise<void> {
   if (util.types) {

--- a/src/variables/NBTs.ts
+++ b/src/variables/NBTs.ts
@@ -1,4 +1,4 @@
-import util from 'util'
+import * as util from 'util'
 
 import type { NBTObject, RootNBT as NBTObj, RootNBT } from '@arguments'
 

--- a/src/variables/parsers.ts
+++ b/src/variables/parsers.ts
@@ -1,4 +1,4 @@
-import util from 'util'
+import * as util from 'util'
 
 import { VectorClass } from './Coordinates'
 


### PR DESCRIPTION
In some modules without import, for example `util`, `import util from 'util'` is allowed but the imported module has `any` type. This may lead to situations like this: `util.inspect.custom` has `any` type, thus `NBTCustomObject` matches any type with `toString(): string`.
![image](https://user-images.githubusercontent.com/63411784/122359851-2052e880-cf80-11eb-9dc9-110d57565033.png)
This pull request fixed that by using `import * as ... from ...` for modules without default import.